### PR TITLE
Feat/support multi level association

### DIFF
--- a/association.go
+++ b/association.go
@@ -1,0 +1,427 @@
+package gofacto
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+
+	"github.com/eyo-chen/gofacto/internal/db"
+)
+
+// assocNode is the association node.
+// Each node contains it's metadata and the list of foreign key references
+type assocNode struct {
+	name         string
+	vals         []interface{}
+	tableName    string
+	ignoreFields []string
+	dependencies []fkRef
+}
+
+// fkRef is the foreign key reference
+type fkRef struct {
+	vals         []interface{}
+	tableName    string
+	fieldName    string
+	foreignField string
+}
+
+// nodeInfo is used to store the information of a node for later reference.
+//
+// e.g. "User" -> {vals: [User1, User2, User3], tableName: "users"}
+type nodeInfo struct {
+	vals      []interface{}
+	tableName string
+}
+
+// insertWithAssoc inserts both factory value and its associations into the database
+func (b *builder[T]) insertWithAssoc(ctx context.Context) (T, error) {
+	// add factory value into association
+	b.f.associations = append(b.f.associations, []interface{}{b.v})
+
+	res, err := b.f.prepareAndInsertAssoc(ctx)
+	if err != nil {
+		return b.f.empty, err
+	}
+
+	v, ok := res[0].(*T)
+	if !ok {
+		return b.f.empty, errCantCvtToPtr
+	}
+
+	return *v, nil
+}
+
+// insertWithAssoc inserts both factory value and its associations into the database
+func (b *builderList[T]) insertWithAssoc(ctx context.Context) ([]T, error) {
+	// add factory value into association
+	vals := make([]interface{}, len(b.list))
+	for i, v := range b.list {
+		vals[i] = v
+	}
+	b.f.associations = append(b.f.associations, vals)
+
+	res, err := b.f.prepareAndInsertAssoc(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	ts := make([]T, len(res))
+	for i, val := range res {
+		v, ok := val.(*T)
+		if !ok {
+			return nil, errCantCvtToPtr
+		}
+
+		ts[i] = *v
+	}
+
+	return ts, nil
+}
+
+// prepareAndInsertAssoc handles the preparation and insertion of associations
+func (f *Factory[T]) prepareAndInsertAssoc(ctx context.Context) ([]interface{}, error) {
+	// create node info map
+	nodeInfoMap, err := f.genNodeInfoMap()
+	if err != nil {
+		return nil, err
+	}
+
+	// generate deep association nodes
+	deepAssoc, err := f.genAssocNodes(nodeInfoMap)
+	if err != nil {
+		return nil, err
+	}
+
+	// insert the deep association nodes into the database
+	return f.insertAssocNode(ctx, deepAssoc)
+}
+
+// insertAssocNode inserts the association nodes into the database.
+// It first sets the foreign key fields for each node, then insert the node into the database.
+func (f *Factory[T]) insertAssocNode(ctx context.Context, nodes []assocNode) ([]interface{}, error) {
+	var fVal []interface{}
+
+	// each node might have multiple values and dependencies
+	// e.g. SubCategory have User and MainCategory
+	// for each subCategory, has to set the foreign key fields for User and MainCategory
+	// cache is used to handle the case when the dependency is less than the number of values
+	// e.g. SubCategory*3, User*2, MainCategory*1
+	// for the 1st SubCategory, set the foreign key fields for User1 and MainCategory1
+	// for the 2nd SubCategory, set the foreign key fields for User2 and MainCategory1
+	// for the 3rd SubCategory, set the foreign key fields for User2 and MainCategory1
+	// nodes are guaranteed to have correct oreder
+	// 1. user is populated with random values, and insert into db
+	// 2. mainCategory is populated with random values, and insert into db
+	// 3. subCategory is populated with random values, and insert into db
+	for _, node := range nodes {
+		cache := map[string]interface{}{}
+		for i, v := range node.vals {
+			for _, dep := range node.dependencies {
+				var d interface{}
+				if i >= len(dep.vals) {
+					d = cache[dep.fieldName]
+				} else {
+					d = dep.vals[i]
+					cache[dep.fieldName] = d
+				}
+
+				if d == nil {
+					continue
+				}
+
+				// set the foreign key field
+				if err := setForeignKey(v, dep.fieldName, d); err != nil {
+					return nil, err
+				}
+				if dep.foreignField != "" {
+					if err := setField(v, dep.foreignField, d); err != nil {
+						return nil, err
+					}
+				}
+			}
+
+			f.setNonZeroValues(v, node.ignoreFields)
+			f.index++
+		}
+
+		res, err := f.db.InsertList(ctx, db.InsertListParams{StorageName: node.tableName, Values: node.vals})
+		if err != nil {
+			return nil, err
+		}
+
+		// if the node is the factory value, set the fVal, and return later
+		if node.name == reflect.TypeOf(f.empty).Name() {
+			fVal = res
+		}
+	}
+
+	return fVal, nil
+}
+
+// genNodeInfoMap generates the node info map
+func (f *Factory[T]) genNodeInfoMap() (map[string]nodeInfo, error) {
+	nodeInfoMap := make(map[string]nodeInfo)
+
+	// it's guaranteed that the each element in the 1D slice is same type
+	// so we can use the 1st element to get the type
+	// along with the iteration, we only cares two things:
+	// (1) vals: the vals in each iteration
+	// (2) tableName: can only know when processing the fields of the struct
+	// note that tableName is only found out in other's struct fields
+	// e.g. SubCategory has User, we can only know the tableName of User when processing the fields of SubCategory
+	for _, vals := range f.associations {
+		val := vals[0]
+		typ := reflect.TypeOf(val).Elem()
+		name := typ.Name()
+		updateNodeInfoMap(nodeInfoMap, vals, name, "") // update the vals field
+		err := processStructFields(typ, func(t tag, hasTag bool) error {
+			if t.omit || !hasTag {
+				return nil
+			}
+
+			updateNodeInfoMap(nodeInfoMap, nil, t.structName, t.tableName) // update the tableName field
+
+			return nil
+		})
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// add the factory value into nodeInfoMap
+	// the last element is guaranteed to be the factory value
+	// it's implemented by the caller to avoid passing unnecessary vals
+	// the logic here is tricky but necessary
+	// because the factory value is not referenced by other association values
+	// e.g. SubCategory*3, User*2, MainCategory*1
+	// the factory value(SubCategory) is not referenced by other association values
+	// so we have to manually add it's info into the nodeInfoMap
+	name := reflect.TypeOf(f.empty).Name()
+	nodeInfoMap[name] = nodeInfo{
+		tableName: f.storageName,
+		vals:      f.associations[len(f.associations)-1],
+	}
+
+	return nodeInfoMap, nil
+}
+
+// updateNodeInfoMap updates the node info map
+func updateNodeInfoMap(nodeInfoMap map[string]nodeInfo, vals []interface{}, name, tableName string) {
+	if info, ok := nodeInfoMap[name]; ok {
+		if len(vals) > 0 {
+			info.vals = vals
+		}
+
+		if tableName != "" {
+			info.tableName = tableName
+		}
+
+		nodeInfoMap[name] = info
+	} else {
+		nodeInfoMap[name] = nodeInfo{
+			vals:      vals,
+			tableName: tableName,
+		}
+	}
+}
+
+// genAssocNodes returns the association nodes in topological order.
+// If there's a cycle dependency, it returns an error
+func (f *Factory[T]) genAssocNodes(nodeInfoMap map[string]nodeInfo) ([]assocNode, error) {
+	d := newDAG()
+
+	// it's guaranteed that the each element in the 1D slice is same type
+	// so we can use the 1st element to get the type
+	for _, vals := range f.associations {
+		typ := reflect.TypeOf(vals[0]).Elem()
+		name := typ.Name()
+
+		deepAssoc := assocNode{
+			name:      name,
+			vals:      vals,
+			tableName: nodeInfoMap[name].tableName,
+		}
+
+		// process the fields to find out the dependencies
+		err := processStructFields(typ, func(t tag, hasTag bool) error {
+			if !hasTag {
+				return nil
+			}
+
+			if t.omit {
+				deepAssoc.ignoreFields = append(deepAssoc.ignoreFields, t.fieldName)
+				return nil
+			}
+
+			deepAssoc.dependencies = append(deepAssoc.dependencies, fkRef{
+				vals:         nodeInfoMap[t.structName].vals,
+				tableName:    t.tableName,
+				fieldName:    t.fieldName,
+				foreignField: t.foreignField,
+			})
+
+			// e.g. User(fk) -> SubCategory
+			d.addEdge(t.structName, name)
+			return nil
+		})
+
+		if err != nil {
+			return nil, err
+		}
+
+		d.addNode(deepAssoc)
+	}
+
+	if d.hasCycle() {
+		return nil, errCycleDependency
+	}
+
+	return d.topologicalSort(), nil
+}
+
+// setForeignKey sets the value of the source's ID field to the target's foreign key(name) field
+func setForeignKey(target interface{}, name string, source interface{}) error {
+	targetField := reflect.ValueOf(target).Elem().FieldByName(name)
+	if !targetField.IsValid() {
+		return fmt.Errorf("%s: %w", name, errFieldNotFound)
+	}
+
+	if !targetField.CanSet() {
+		return fmt.Errorf("%s: %w", name, errFieldCantSet)
+	}
+
+	sourceIDField := reflect.ValueOf(source).Elem().FieldByName("ID")
+	if !sourceIDField.IsValid() {
+		return fmt.Errorf("%s: %w", "ID", errFieldNotFound)
+	}
+
+	sourceIDKind := sourceIDField.Kind()
+	if !isIntType(sourceIDKind) && !isUintType(sourceIDKind) {
+		return errNotInt
+	}
+
+	setIntValue(targetField, sourceIDField)
+	return nil
+}
+
+// setIntValue sets the value of the source to the target,
+// and it also handles the conversion between int and uint.
+// Normally, it's used to set the ID field of the target struct
+func setIntValue(target, source reflect.Value) {
+	if target.Kind() == reflect.Ptr {
+		target = target.Elem()
+	}
+
+	targetKind := target.Kind()
+	sourceKind := source.Kind()
+
+	if isIntType(targetKind) && isIntType(sourceKind) {
+		target.SetInt(source.Int())
+		return
+	}
+
+	if isUintType(targetKind) && isUintType(sourceKind) {
+		target.SetUint(source.Uint())
+		return
+	}
+
+	if isIntType(targetKind) {
+		target.SetInt(int64(source.Uint()))
+		return
+	}
+
+	target.SetUint(uint64(source.Int()))
+}
+
+// isIntType checks if the kind is an integer type
+func isIntType(k reflect.Kind) bool {
+	return k >= reflect.Int && k <= reflect.Int64
+}
+
+// isUintType checks if the kind is an unsigned integer type
+func isUintType(k reflect.Kind) bool {
+	return k >= reflect.Uint && k <= reflect.Uint64
+}
+
+// serField sets the value of the source to the field of the target.
+// field value of target might be a pointer or value.
+// field and source must be a pointer.
+func setField(target interface{}, fieldName string, source interface{}) error {
+	structValue := reflect.ValueOf(target).Elem()
+	fieldVal := structValue.FieldByName(fieldName)
+
+	if !fieldVal.IsValid() {
+		return fmt.Errorf("%s: %w", fieldName, errFieldNotFound)
+	}
+
+	if !fieldVal.CanSet() {
+		return fmt.Errorf("%s: %w", fieldName, errFieldCantSet)
+	}
+
+	sourceVal := reflect.ValueOf(source).Elem()
+
+	// when fieldVal is a pointer
+	if fieldVal.Kind() == reflect.Ptr {
+		// If fieldVal is nil, create a new instance
+		if fieldVal.IsNil() {
+			fieldVal.Set(reflect.New(fieldVal.Type().Elem()))
+		}
+
+		// check if the type of the pointer is the same as the source
+		if fieldVal.Type().Elem() != sourceVal.Type() {
+			return fmt.Errorf("type mismatch: field %s is %v, source is %v", fieldName, fieldVal.Type().Elem(), sourceVal.Type())
+		}
+
+		// set the value of the pointer to the source
+		fieldVal.Elem().Set(sourceVal)
+		return nil
+	}
+
+	// when fieldVal is a value
+	if fieldVal.Type() != sourceVal.Type() {
+		return fmt.Errorf("type mismatch: field %s is %v, source is %v", fieldName, fieldVal.Type(), sourceVal.Type())
+	}
+	fieldVal.Set(sourceVal)
+
+	return nil
+}
+
+// checkAssoc checks if the input association value is valid
+func checkAssoc(v interface{}) error {
+	typeOfV := reflect.TypeOf(v)
+
+	// check if it's a pointer
+	if typeOfV.Kind() != reflect.Ptr {
+		name := typeOfV.Name()
+		return fmt.Errorf("%s, %v: %w", name, v, errIsNotPtr)
+	}
+
+	// check if it's a pointer to a struct
+	if typeOfV.Elem().Kind() != reflect.Struct {
+		name := typeOfV.Elem().Name()
+		return fmt.Errorf("%s, %v: %w", name, v, errIsNotStructPtr)
+	}
+
+	return nil
+}
+
+// checkAssocs checks if the input association values are valid
+func checkAssocs(vals []interface{}) error {
+	var name string
+	for _, v := range vals {
+		if err := checkAssoc(v); err != nil {
+			return err
+		}
+
+		// check if the type of the value is the same as the previous value
+		curValName := reflect.TypeOf(v).Elem().Name()
+		if name != "" && name != curValName {
+			return errValueNotTheSameType
+		}
+
+		name = curValName
+	}
+
+	return nil
+}

--- a/dag.go
+++ b/dag.go
@@ -1,0 +1,85 @@
+package gofacto
+
+type dag struct {
+	nodes map[string]assocNode
+	edges map[string][]string
+}
+
+func newDAG() *dag {
+	return &dag{
+		nodes: make(map[string]assocNode),
+		edges: make(map[string][]string),
+	}
+}
+
+func (d *dag) addNode(node assocNode) {
+	d.nodes[node.name] = node
+}
+
+func (d *dag) addEdge(from, to string) {
+	d.edges[from] = append(d.edges[from], to)
+}
+
+// topologicalSort returns the topological sort of the DAG
+func (d *dag) topologicalSort() []assocNode {
+	visited := make(map[string]bool)
+	result := make([]assocNode, len(d.nodes))
+	i := len(result) - 1
+
+	var dfs func(node string)
+	dfs = func(node string) {
+		if visited[node] {
+			return
+		}
+
+		visited[node] = true
+		for _, neighbor := range d.edges[node] {
+			dfs(neighbor)
+		}
+
+		result[i] = d.nodes[node]
+		i--
+	}
+
+	for node := range d.nodes {
+		dfs(node)
+	}
+
+	return result
+}
+
+// hasCycle returns true if the DAG has a cycle
+func (d *dag) hasCycle() bool {
+	visited := make(map[string]bool)
+	recursionStack := make(map[string]bool)
+
+	var dfs func(node string) bool
+	dfs = func(node string) bool {
+		if recursionStack[node] {
+			return true
+		}
+
+		if visited[node] {
+			return false
+		}
+
+		visited[node] = true
+		recursionStack[node] = true
+		for _, neighbor := range d.edges[node] {
+			if dfs(neighbor) {
+				return true
+			}
+		}
+
+		recursionStack[node] = false
+		return false
+	}
+
+	for node := range d.nodes {
+		if dfs(node) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/db/gormf/gormf_test.go
+++ b/db/gormf/gormf_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 	"time"
 
-	"gorm.io/datatypes"
 	"gorm.io/driver/mysql"
 	"gorm.io/gorm"
 	"gorm.io/gorm/logger"
@@ -24,48 +23,69 @@ var (
 )
 
 type Author struct {
-	ID                  int64           `gorm:"id;primaryKey"`
-	FirstName           string          `gorm:"first_name"`
-	LastName            string          `gorm:"last_name"`
-	BirthDate           *time.Time      `gorm:"birth_date"`
-	Nationality         *string         `gorm:"nationalality"`
-	Email               *string         `gorm:"email"`
-	Biography           *string         `gorm:"biography"`
-	IsActive            bool            `gorm:"is_active"`
-	Rating              *float64        `gorm:"rating"`
-	BooksWritten        *int32          `gorm:"books_written"`
-	LastPublicationTime time.Time       `gorm:"last_publication_time"`
-	WebsiteURL          *string         `gorm:"website_url"`
-	FanCount            *int64          `gorm:"fan_count"`
-	ProfilePicture      []byte          `gorm:"profile_picture"`
-	BornTime            datatypes.Time  `gorm:"born_time"`
-	BornTime1           *datatypes.Time `gorm:"born_time1"`
+	ID                  int64
+	FirstName           string
+	LastName            string
+	BirthDate           *time.Time
+	Nationality         *string
+	Email               string
+	Biography           *string
+	IsActive            bool
+	Rating              *float64
+	BooksWritten        *int32
+	LastPublicationTime time.Time
+	WebsiteURL          *string
+	FanCount            *int64
+	ProfilePicture      []byte
 }
 
 type Book struct {
-	ID               int64           `gorm:"id;primaryKey"`
-	AuthorID         int64           `gorm:"author_id" gofacto:"foreignKey,struct:Author,field:Author"`
-	Author           *Author         `gorm:"foreignKey:AuthorID"`
-	Title            string          `gorm:"title"`
-	ISBN             *string         `gorm:"isbn"`
-	PublicationDate  datatypes.Date  `gorm:"publication_date"`
-	PublicationDate1 *datatypes.Date `gorm:"publication_date1"`
-	Genre            *string         `gorm:"genre"`
-	Price            *float64        `gorm:"price"`
-	PageCount        *int32          `gorm:"page_count"`
-	Description      *string         `gorm:"description"`
-	InStock          bool            `gorm:"in_stock"`
-	CoverImage       []byte          `gorm:"cover_image"`
-	Data             datatypes.JSON  `gorm:"data"`
-	Data1            *datatypes.JSON `gorm:"data1"`
-	CreatedAt        time.Time       `gorm:"created_at"`
-	UpdatedAt        time.Time       `gorm:"updated_at"`
+	ID              int64
+	AuthorID        int64 `gofacto:"foreignKey,struct:Author"`
+	CategoryID      int64 `gofacto:"foreignKey,struct:Category,table:categories"`
+	SubCategoryID   int64 `gofacto:"foreignKey,struct:SubCategory,table:sub_categories"`
+	Title           string
+	ISBN            *string
+	PublicationDate *time.Time
+	Genre           *string
+	Price           *float64
+	PageCount       *int32
+	Description     *string
+	InStock         bool
+	CoverImage      []byte
+	CreatedAt       time.Time
+	UpdatedAt       time.Time
+}
+
+type Category struct {
+	ID          int64
+	Name        string
+	AuthorID    int64 `gofacto:"foreignKey,struct:Author"`
+	Description *string
+	CreatedAt   time.Time
+	UpdatedAt   time.Time
+}
+
+type SubCategory struct {
+	ID          int64
+	CategoryID  int64 `gofacto:"foreignKey,struct:Category,table:categories"`
+	AuthorID    int64 `gofacto:"foreignKey,struct:Author"`
+	Name        string
+	Description *string
+	CreatedAt   time.Time
+	UpdatedAt   time.Time
 }
 
 type testingSuite struct {
-	db      *gorm.DB
-	authorF *gofacto.Factory[Author]
-	bookF   *gofacto.Factory[Book]
+	db        *gorm.DB
+	authorF   *gofacto.Factory[Author]
+	bookF     *gofacto.Factory[Book]
+	categoryF *gofacto.Factory[Category]
+}
+
+func bookBlueprint(i int) Book {
+	mockGenre := "Fiction"
+	return Book{Genre: &mockGenre}
 }
 
 func (s *testingSuite) setupSuite() {
@@ -103,8 +123,9 @@ func (s *testingSuite) setupSuite() {
 	}
 
 	// set up gofacto factories
-	s.authorF = gofacto.New(Author{}).WithDB(NewConfig(db))
-	s.bookF = gofacto.New(Book{}).WithDB(NewConfig(db))
+	s.authorF = gofacto.New(Author{}).WithDB(NewConfig(s.db))
+	s.bookF = gofacto.New(Book{}).WithDB(NewConfig(s.db)).WithBlueprint(bookBlueprint)
+	s.categoryF = gofacto.New(Category{}).WithDB(NewConfig(s.db)).WithStorageName("categories")
 }
 
 func (s *testingSuite) tearDownSuite() error {
@@ -128,9 +149,17 @@ func (s *testingSuite) tearDownTest() error {
 		return err
 	}
 
+	if err := s.db.Exec("DELETE FROM categories").Error; err != nil {
+		return err
+	}
+
+	if err := s.db.Exec("DELETE FROM sub_categories").Error; err != nil {
+		return err
+	}
+
 	s.authorF.Reset()
 	s.bookF.Reset()
-
+	s.categoryF.Reset()
 	return nil
 }
 
@@ -143,7 +172,7 @@ func (s *testingSuite) Run(t *testing.T) {
 		{"TestInsertList", s.TestInsertList},
 		{"TestWithOne", s.TestWithOne},
 		{"TestWithMany", s.TestWithMany},
-		{"TestListWithOne", s.TestListWithOne},
+		// {"TestListWithOne", s.TestListWithOne},
 	}
 
 	for _, test := range tests {
@@ -213,90 +242,505 @@ func (s *testingSuite) TestInsertList(t *testing.T) {
 }
 
 func (s *testingSuite) TestWithOne(t *testing.T) {
+	for _, fn := range map[string]func(*testingSuite, *testing.T){
+		"when on builder, insert with association correctly":                              withOne_OnBuilder,
+		"when on builder list, insert with association correctly":                         withOne_OnBuilderList,
+		"when on builder with multi level association, insert with association correctly": withOne_OnBuilderWithMultiLevelAssociation,
+	} {
+		t.Run(testutils.GetFunName(fn), func(t *testing.T) {
+			fn(s, t)
+			if err := s.tearDownTest(); err != nil {
+				t.Fatalf("Failed to tear down test: %s", err)
+			}
+		})
+	}
+}
+
+func withOne_OnBuilder(s *testingSuite, t *testing.T) {
 	// prepare mock data
 	mockAuthor := Author{}
-	mockGenre := "Science"
-	ow := Book{Genre: &mockGenre} // set correct enum value
-	mockBook, err := s.bookF.Build(mockCTX).Overwrite(ow).WithOne(&mockAuthor).Insert()
+	mockCategory, err := s.categoryF.Build(mockCTX).WithOne(&mockAuthor).Insert()
 	if err != nil {
 		t.Fatalf("Failed to insert: %s", err)
 	}
 
 	// prepare expected data
+	var category Category
+	if err := s.db.First(&category, mockCategory.ID).Error; err != nil {
+		t.Fatalf("Failed to find category: %s", err)
+	}
+
+	var author Author
+	if err := s.db.First(&author, mockCategory.AuthorID).Error; err != nil {
+		t.Fatalf("Failed to find author: %s", err)
+	}
+
+	// assertion
+	if err := testutils.CompareVal(mockCategory, category, "CreatedAt", "UpdatedAt"); err != nil {
+		t.Fatalf("Inserted category is not the same as the mock category: %s", err)
+	}
+
+	if err := testutils.CompareVal(mockAuthor, author, "BirthDate", "LastPublicationTime"); err != nil {
+		t.Fatalf("Inserted author is not the same as the mock author: %s", err)
+	}
+
+	// check if the association is correctly set
+	if mockCategory.AuthorID != mockAuthor.ID {
+		t.Fatalf("Inserted category author id is not the same as the mock author id: %d", mockCategory.AuthorID)
+	}
+}
+
+func withOne_OnBuilderList(s *testingSuite, t *testing.T) {
+	// prepare mock data
+	mockRating := 4.5
+	mockAuthor := Author{Rating: &mockRating}
+	mockCategories, err := s.categoryF.
+		BuildList(mockCTX, 3).
+		WithOne(&mockAuthor).
+		Insert()
+	if err != nil {
+		t.Fatalf("Failed to insert categories: %s", err)
+	}
+
+	// prepare expected data
+	var categories []Category
+	if err := s.db.Where("author_id = ?", mockCategories[0].AuthorID).Find(&categories).Error; err != nil {
+		t.Fatalf("Failed to find categories: %s", err)
+	}
+
+	var author Author
+	if err := s.db.First(&author, mockCategories[0].AuthorID).Error; err != nil {
+		t.Fatalf("Failed to find author: %s", err)
+	}
+
+	// assertion
+	if err := testutils.CompareVal(mockCategories, categories, "CreatedAt", "UpdatedAt"); err != nil {
+		t.Fatalf("Inserted categories are not the same as the mock categories: %s", err)
+	}
+
+	if err := testutils.CompareVal(mockAuthor, author, "BirthDate", "LastPublicationTime"); err != nil {
+		t.Fatalf("Inserted author is not the same as the mock author: %s", err)
+	}
+
+	// check if the association is correctly set
+	for _, c := range categories {
+		if c.AuthorID != mockAuthor.ID {
+			t.Fatalf("Inserted category author id is not the same as the mock author id: %d", c.AuthorID)
+		}
+	}
+}
+
+func withOne_OnBuilderWithMultiLevelAssociation(s *testingSuite, t *testing.T) {
+	// prepare mock data
+	mockAuthor := Author{}
+	mockCategory := Category{}
+	mockSubCategory := SubCategory{}
+
+	mockBook, err := s.bookF.
+		Build(mockCTX).
+		WithOne(&mockAuthor, &mockCategory, &mockSubCategory).
+		Insert()
+	if err != nil {
+		t.Fatalf("Failed to insert book: %s", err)
+	}
+
+	// prepare expected data
+	var author Author
+	if err := s.db.First(&author, mockBook.AuthorID).Error; err != nil {
+		t.Fatalf("Failed to find author: %s", err)
+	}
+
+	var category Category
+	if err := s.db.First(&category, mockBook.CategoryID).Error; err != nil {
+		t.Fatalf("Failed to find author: %s", err)
+	}
+
+	var subCategory SubCategory
+	if err := s.db.First(&subCategory, mockBook.SubCategoryID).Error; err != nil {
+		t.Fatalf("Failed to find sub category: %s", err)
+	}
+
 	var book Book
-	if err := s.db.Where("author_id = ?", mockBook.AuthorID).Preload("Author").First(&book).Error; err != nil {
+	if err := s.db.First(&book, mockBook.ID).Error; err != nil {
 		t.Fatalf("Failed to find book: %s", err)
 	}
 
 	// assertion
-	if err := testutils.CompareVal(mockBook, book, "PublicationDate", "CreatedAt", "UpdatedAt", "BirthDate", "LastPublicationTime"); err != nil {
+	if err := testutils.CompareVal(mockAuthor, author, "BirthDate", "LastPublicationTime"); err != nil {
+		t.Fatalf("Inserted author is not the same as the mock author: %s", err)
+	}
+
+	if err := testutils.CompareVal(mockCategory, category, "CreatedAt", "UpdatedAt"); err != nil {
+		t.Fatalf("Inserted category is not the same as the mock category: %s", err)
+	}
+
+	if err := testutils.CompareVal(mockSubCategory, subCategory, "CreatedAt", "UpdatedAt"); err != nil {
+		t.Fatalf("Inserted sub category is not the same as the mock sub category: %s", err)
+	}
+
+	if err := testutils.CompareVal(mockBook, book, "CreatedAt", "UpdatedAt", "PublicationDate"); err != nil {
 		t.Fatalf("Inserted book is not the same as the mock book: %s", err)
 	}
 
-	if err := testutils.CompareVal(mockAuthor, *book.Author, "BirthDate", "LastPublicationTime"); err != nil {
-		t.Fatalf("Inserted author is not the same as the mock author: %s", err)
+	// check if the association is correctly set
+	// check book association
+	if mockBook.AuthorID != mockAuthor.ID {
+		t.Fatalf("Inserted book author id is not the same as the mock author id: %d", mockBook.AuthorID)
+	}
+	if mockBook.CategoryID != mockCategory.ID {
+		t.Fatalf("Inserted book category id is not the same as the mock category id: %d", mockBook.CategoryID)
+	}
+	if mockBook.SubCategoryID != mockSubCategory.ID {
+		t.Fatalf("Inserted book sub category id is not the same as the mock sub category id: %d", mockBook.SubCategoryID)
+	}
+
+	// check category association
+	if mockCategory.AuthorID != mockAuthor.ID {
+		t.Fatalf("Inserted category author id is not the same as the mock author id: %d", mockCategory.AuthorID)
+	}
+
+	// check sub category association
+	if mockSubCategory.AuthorID != mockAuthor.ID {
+		t.Fatalf("Inserted sub category author id is not the same as the mock author id: %d", mockSubCategory.AuthorID)
+	}
+	if mockSubCategory.CategoryID != mockCategory.ID {
+		t.Fatalf("Inserted sub category category id is not the same as the mock category id: %d", mockSubCategory.CategoryID)
 	}
 }
 
 func (s *testingSuite) TestWithMany(t *testing.T) {
-	// prepare mock data
-	mockAnyAuthors := make([]interface{}, 3)
-	for i := 0; i < 3; i++ {
-		mockAnyAuthors[i] = &Author{}
+	for _, fn := range map[string]func(*testingSuite, *testing.T){
+		"when association and factory value same amount, insert with association correctly":                  withMany_AssocAndFactoryValSameAmount,
+		"when association and factory value different amount, insert with association correctly":             withMany_AssocAndFactoryValDiffAmount,
+		"when multi level association and factory value same amount, insert with association correctly":      withMany_MultiLevelSameAmount,
+		"when multi level association and factory value different amount, insert with association correctly": withMany_MultiLevelDiffAmount,
+	} {
+		t.Run(testutils.GetFunName(fn), func(t *testing.T) {
+			fn(s, t)
+			if err := s.tearDownTest(); err != nil {
+				t.Fatalf("Failed to tear down test: %s", err)
+			}
+		})
 	}
-	mockGenre := "Science"
-	ow := Book{Genre: &mockGenre} // set correct enum value
-	mockBooks, err := s.bookF.BuildList(mockCTX, 3).Overwrite(ow).WithMany(mockAnyAuthors).Insert()
+}
+
+func withMany_AssocAndFactoryValSameAmount(s *testingSuite, t *testing.T) {
+	// prepare mock data
+	mockAuthorAmount := 3
+	mockAnyAuthors := make([]interface{}, mockAuthorAmount)
+	mockRating := 2.0
+	for i := 0; i < mockAuthorAmount; i++ {
+		mockAnyAuthors[i] = &Author{Rating: &mockRating}
+	}
+	mockCategories, err := s.categoryF.BuildList(mockCTX, 3).WithMany(mockAnyAuthors).Insert()
+	if err != nil {
+		t.Fatalf("Failed to insert categories: %s", err)
+	}
+
+	mockAuthors := make([]Author, mockAuthorAmount)
+	for i := 0; i < mockAuthorAmount; i++ {
+		mockAuthors[i] = *mockAnyAuthors[i].(*Author)
+	}
+
+	// prepare expected data
+	// loop through each data to check association connection
+	for i := 0; i < mockAuthorAmount; i++ {
+		var category Category
+		if err := s.db.First(&category, mockCategories[i].ID).Error; err != nil {
+			t.Fatalf("Failed to find category: %s", err)
+		}
+
+		var author Author
+		if err := s.db.First(&author, mockCategories[i].AuthorID).Error; err != nil {
+			t.Fatalf("Failed to find author: %s", err)
+		}
+
+		// assertion
+		if err := testutils.CompareVal(mockCategories[i], category, "CreatedAt", "UpdatedAt"); err != nil {
+			t.Fatalf("Inserted category is not the same as the mock category: %s", err)
+		}
+
+		if err := testutils.CompareVal(mockAuthors[i], author, "BirthDate", "LastPublicationTime"); err != nil {
+			t.Fatalf("Inserted author is not the same as the mock author: %s", err)
+		}
+
+		// check if the association is correctly set
+		if mockCategories[i].AuthorID != mockAuthors[i].ID {
+			t.Fatalf("Inserted category author id is not the same as the mock author id: %d", mockCategories[i].AuthorID)
+		}
+	}
+}
+
+func withMany_AssocAndFactoryValDiffAmount(s *testingSuite, t *testing.T) {
+	// prepare mock data
+	mockAuthorAmount := 2
+	mockAnyAuthors := make([]interface{}, mockAuthorAmount)
+	mockRating := 2.0
+	for i := 0; i < mockAuthorAmount; i++ {
+		mockAnyAuthors[i] = &Author{Rating: &mockRating}
+	}
+	mockCategories, err := s.categoryF.BuildList(mockCTX, 3).WithMany(mockAnyAuthors).Insert()
+	if err != nil {
+		t.Fatalf("Failed to insert categories: %s", err)
+	}
+
+	mockAuthors := make([]Author, mockAuthorAmount)
+	for i := 0; i < mockAuthorAmount; i++ {
+		mockAuthors[i] = *mockAnyAuthors[i].(*Author)
+	}
+
+	// prepare expected data
+	// loop through each data to check association connection
+	for i := 0; i < 3; i++ {
+		// because we only have 2 authors, we need to loop back to the last author
+		mockAuthorIdx := i
+		if mockAuthorIdx >= mockAuthorAmount {
+			mockAuthorIdx = mockAuthorAmount - 1
+		}
+
+		var category Category
+		if err := s.db.First(&category, mockCategories[i].ID).Error; err != nil {
+			t.Fatalf("Failed to find category: %s", err)
+		}
+
+		var author Author
+		if err := s.db.First(&author, mockCategories[i].AuthorID).Error; err != nil {
+			t.Fatalf("Failed to find author: %s", err)
+		}
+
+		// assertion
+		if err := testutils.CompareVal(mockCategories[i], category, "CreatedAt", "UpdatedAt"); err != nil {
+			t.Fatalf("Inserted category is not the same as the mock category: %s", err)
+		}
+
+		if err := testutils.CompareVal(mockAuthors[mockAuthorIdx], author, "BirthDate", "LastPublicationTime"); err != nil {
+			t.Fatalf("Inserted author is not the same as the mock author: %s", err)
+		}
+
+		// check if the association is correctly set
+		if mockCategories[i].AuthorID != mockAuthors[mockAuthorIdx].ID {
+			t.Fatalf("Inserted category author id is not the same as the mock author id: %d", mockCategories[i].AuthorID)
+		}
+	}
+}
+
+func withMany_MultiLevelSameAmount(s *testingSuite, t *testing.T) {
+	// prepare mock data
+	mockAuthor := make([]interface{}, 3)
+	for i := 0; i < 3; i++ {
+		mockAuthor[i] = &Author{}
+	}
+
+	mockCategory := make([]interface{}, 3)
+	for i := 0; i < 3; i++ {
+		mockCategory[i] = &Category{}
+	}
+
+	mockSubCategory := make([]interface{}, 3)
+	for i := 0; i < 3; i++ {
+		mockSubCategory[i] = &SubCategory{}
+	}
+
+	mockBooks, err := s.bookF.
+		BuildList(mockCTX, 3).
+		WithMany(mockAuthor).
+		WithMany(mockCategory).
+		WithMany(mockSubCategory).
+		Insert()
 	if err != nil {
 		t.Fatalf("Failed to insert books: %s", err)
 	}
 
 	mockAuthors := make([]Author, 3)
 	for i := 0; i < 3; i++ {
-		mockAuthors[i] = *mockAnyAuthors[i].(*Author)
+		mockAuthors[i] = *mockAuthor[i].(*Author)
 	}
 
-	// loop through each data to check association connection
+	mockCategories := make([]Category, 3)
+	for i := 0; i < 3; i++ {
+		mockCategories[i] = *mockCategory[i].(*Category)
+	}
+
+	mockSubCategories := make([]SubCategory, 3)
+	for i := 0; i < 3; i++ {
+		mockSubCategories[i] = *mockSubCategory[i].(*SubCategory)
+	}
+
 	for i := 0; i < 3; i++ {
 		// prepare expected data
-		var book Book
-		if err := s.db.Where("author_id = ?", mockBooks[i].AuthorID).Preload("Author").First(&book).Error; err != nil {
-			t.Fatalf("Failed to find book: %s", err)
+		var author Author
+		if err := s.db.First(&author, mockBooks[i].AuthorID).Error; err != nil {
+			t.Fatalf("Failed to find author: %s", err)
+		}
+
+		var category Category
+		if err := s.db.First(&category, mockBooks[i].CategoryID).Error; err != nil {
+			t.Fatalf("Failed to find category: %s", err)
+		}
+
+		var subCategory SubCategory
+		if err := s.db.First(&subCategory, mockBooks[i].SubCategoryID).Error; err != nil {
+			t.Fatalf("Failed to find sub category: %s", err)
 		}
 
 		// assertion
-		if err := testutils.CompareVal(mockBooks[i], book, "PublicationDate", "CreatedAt", "UpdatedAt", "BirthDate", "LastPublicationTime"); err != nil {
-			t.Fatalf("Inserted book is not the same as the mock book: %s", err)
+		if err := testutils.CompareVal(mockAuthors[i], author, "BirthDate", "LastPublicationTime"); err != nil {
+			t.Fatalf("Inserted author is not the same as the mock author: %s", err)
 		}
 
-		if err := testutils.CompareVal(mockAuthors[i], *book.Author, "BirthDate", "LastPublicationTime"); err != nil {
-			t.Fatalf("Inserted author is not the same as the mock author: %s", err)
+		if err := testutils.CompareVal(mockCategories[i], category, "CreatedAt", "UpdatedAt"); err != nil {
+			t.Fatalf("Inserted category is not the same as the mock category: %s", err)
+		}
+
+		if err := testutils.CompareVal(mockSubCategories[i], subCategory, "CreatedAt", "UpdatedAt"); err != nil {
+			t.Fatalf("Inserted sub category is not the same as the mock sub category: %s", err)
+		}
+
+		// check if the association is correctly set
+		// check book association
+		if mockBooks[i].AuthorID != mockAuthors[i].ID {
+			t.Fatalf("Inserted book author id is not the same as the mock author id: %d", mockBooks[i].AuthorID)
+		}
+		if mockBooks[i].CategoryID != mockCategories[i].ID {
+			t.Fatalf("Inserted book category id is not the same as the mock category id: %d", mockBooks[i].CategoryID)
+		}
+		if mockBooks[i].SubCategoryID != mockSubCategories[i].ID {
+			t.Fatalf("Inserted book sub category id is not the same as the mock sub category id: %d", mockBooks[i].SubCategoryID)
+		}
+
+		// check category association
+		if mockCategories[i].AuthorID != mockAuthors[i].ID {
+			t.Fatalf("Inserted category author id is not the same as the mock author id: %d", mockCategories[i].AuthorID)
+		}
+
+		// check sub category association
+		if mockSubCategories[i].AuthorID != mockAuthors[i].ID {
+			t.Fatalf("Inserted sub category author id is not the same as the mock author id: %d", mockSubCategories[i].AuthorID)
+		}
+		if mockSubCategories[i].CategoryID != mockCategories[i].ID {
+			t.Fatalf("Inserted sub category category id is not the same as the mock category id: %d", mockSubCategories[i].CategoryID)
 		}
 	}
 }
 
-func (s *testingSuite) TestListWithOne(t *testing.T) {
+func withMany_MultiLevelDiffAmount(s *testingSuite, t *testing.T) {
 	// prepare mock data
-	mockAuthor := Author{}
-	mockGenre := "Science"
-	ow := Book{Genre: &mockGenre} // set correct enum value
-	mockBooks, err := s.bookF.BuildList(mockCTX, 3).Overwrite(ow).WithOne(&mockAuthor).Insert()
+	mockAuthorAmount := 1
+	mockAuthor := make([]interface{}, mockAuthorAmount)
+	for i := 0; i < mockAuthorAmount; i++ {
+		mockAuthor[i] = &Author{}
+	}
+
+	mockCategoryAmount := 2
+	mockCategory := make([]interface{}, mockCategoryAmount)
+	for i := 0; i < mockCategoryAmount; i++ {
+		mockCategory[i] = &Category{}
+	}
+
+	mockSubCategoryAmount := 3
+	mockSubCategory := make([]interface{}, mockSubCategoryAmount)
+	for i := 0; i < mockSubCategoryAmount; i++ {
+		mockSubCategory[i] = &SubCategory{}
+	}
+
+	mockBooks, err := s.bookF.
+		BuildList(mockCTX, 3).
+		WithMany(mockAuthor).
+		WithMany(mockCategory).
+		WithMany(mockSubCategory).
+		Insert()
 	if err != nil {
 		t.Fatalf("Failed to insert books: %s", err)
 	}
 
-	// prepare expected data
-	var books []Book
-	if err := s.db.Where("author_id = ?", mockBooks[0].AuthorID).Preload("Author").Find(&books).Error; err != nil {
-		t.Fatalf("Failed to find books: %s", err)
+	mockAuthors := make([]Author, mockAuthorAmount)
+	for i := 0; i < mockAuthorAmount; i++ {
+		mockAuthors[i] = *mockAuthor[i].(*Author)
 	}
 
-	// assertion
-	if err := testutils.CompareVal(mockBooks, books, "PublicationDate", "CreatedAt", "UpdatedAt", "BirthDate", "LastPublicationTime"); err != nil {
-		t.Fatalf("Inserted books are not the same as the mock books: %s", err)
+	mockCategories := make([]Category, mockCategoryAmount)
+	for i := 0; i < mockCategoryAmount; i++ {
+		mockCategories[i] = *mockCategory[i].(*Category)
 	}
 
-	if err := testutils.CompareVal(mockAuthor, *books[0].Author, "BirthDate", "LastPublicationTime"); err != nil {
-		t.Fatalf("Inserted author is not the same as the mock author: %s", err)
+	mockSubCategories := make([]SubCategory, mockSubCategoryAmount)
+	for i := 0; i < mockSubCategoryAmount; i++ {
+		mockSubCategories[i] = *mockSubCategory[i].(*SubCategory)
+	}
+
+	for i := 0; i < 3; i++ {
+		mockAuthorIdx := i
+		if mockAuthorIdx >= mockAuthorAmount {
+			mockAuthorIdx = mockAuthorAmount - 1
+		}
+
+		mockCategoryIdx := i
+		if mockCategoryIdx >= mockCategoryAmount {
+			mockCategoryIdx = mockCategoryAmount - 1
+		}
+
+		mockSubCategoryIdx := i
+		if mockSubCategoryIdx >= mockSubCategoryAmount {
+			mockSubCategoryIdx = mockSubCategoryAmount - 1
+		}
+
+		// prepare expected data
+		var author Author
+		if err := s.db.First(&author, mockBooks[i].AuthorID).Error; err != nil {
+			t.Fatalf("Failed to find author: %s", err)
+		}
+
+		var category Category
+		if err := s.db.First(&category, mockBooks[i].CategoryID).Error; err != nil {
+			t.Fatalf("Failed to find category: %s", err)
+		}
+
+		var subCategory SubCategory
+		if err := s.db.First(&subCategory, mockBooks[i].SubCategoryID).Error; err != nil {
+			t.Fatalf("Failed to find sub category: %s", err)
+		}
+
+		// assertion
+		if err != nil {
+			t.Fatalf("Failed to find sub category: %s", err)
+		}
+
+		// assertion
+		if err := testutils.CompareVal(mockAuthors[mockAuthorIdx], author, "BirthDate", "LastPublicationTime"); err != nil {
+			t.Fatalf("Inserted author is not the same as the mock author: %s", err)
+		}
+
+		if err := testutils.CompareVal(mockCategories[mockCategoryIdx], category, "CreatedAt", "UpdatedAt"); err != nil {
+			t.Fatalf("Inserted category is not the same as the mock category: %s", err)
+		}
+
+		if err := testutils.CompareVal(mockSubCategories[mockSubCategoryIdx], subCategory, "CreatedAt", "UpdatedAt"); err != nil {
+			t.Fatalf("Inserted sub category is not the same as the mock sub category: %s", err)
+		}
+
+		// check if the association is correctly set
+		// check book association
+		if mockBooks[i].AuthorID != mockAuthors[mockAuthorIdx].ID {
+			t.Fatalf("Inserted book author id is not the same as the mock author id: %d", mockBooks[i].AuthorID)
+		}
+		if mockBooks[i].CategoryID != mockCategories[mockCategoryIdx].ID {
+			t.Fatalf("Inserted book category id is not the same as the mock category id: %d", mockBooks[i].CategoryID)
+		}
+		if mockBooks[i].SubCategoryID != mockSubCategories[mockSubCategoryIdx].ID {
+			t.Fatalf("Inserted book sub category id is not the same as the mock sub category id: %d", mockBooks[i].SubCategoryID)
+		}
+
+		// check category association
+		if mockCategories[mockCategoryIdx].AuthorID != mockAuthors[mockAuthorIdx].ID {
+			t.Fatalf("Inserted category author id is not the same as the mock author id: %d", mockCategories[mockCategoryIdx].AuthorID)
+		}
+
+		// check sub category association
+		if mockSubCategories[mockSubCategoryIdx].AuthorID != mockAuthors[mockAuthorIdx].ID {
+			t.Fatalf("Inserted sub category author id is not the same as the mock author id: %d", mockSubCategories[mockSubCategoryIdx].AuthorID)
+		}
+		if mockSubCategories[mockSubCategoryIdx].CategoryID != mockCategories[mockCategoryIdx].ID {
+			t.Fatalf("Inserted sub category category id is not the same as the mock category id: %d", mockSubCategories[i].CategoryID)
+		}
 	}
 }

--- a/db/gormf/schema.sql
+++ b/db/gormf/schema.sql
@@ -7,32 +7,53 @@ CREATE TABLE IF NOT EXISTS authors (
     email VARCHAR(100) UNIQUE,
     biography TEXT,
     is_active BOOLEAN DEFAULT TRUE,
-    rating DECIMAL(4,2),
+    rating DECIMAL(3,2),
     books_written INT UNSIGNED,
     last_publication_time TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     website_url VARCHAR(255),
     fan_count BIGINT UNSIGNED,
-    profile_picture BLOB,
-    born_time TIME,
-    born_time1 TIME
+    profile_picture BLOB
+);
+
+CREATE TABLE IF NOT EXISTS categories (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    author_id INT,
+    name VARCHAR(255) NOT NULL,
+    description TEXT,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    FOREIGN KEY (author_id) REFERENCES authors(id) ON DELETE SET NULL
+);
+
+CREATE TABLE IF NOT EXISTS sub_categories (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    category_id INT NOT NULL,
+    author_id INT,
+    name VARCHAR(255) NOT NULL,
+    description TEXT,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    FOREIGN KEY (category_id) REFERENCES categories(id) ON DELETE CASCADE,
+    FOREIGN KEY (author_id) REFERENCES authors(id) ON DELETE SET NULL
 );
 
 CREATE TABLE IF NOT EXISTS books (
     id INT AUTO_INCREMENT PRIMARY KEY,
     author_id INT,
+    category_id INT,
+    sub_category_id INT,
     title VARCHAR(255) NOT NULL,
     isbn CHAR(13) UNIQUE,
     publication_date DATE,
-    publication_date1 DATE,
     genre ENUM('Fiction', 'Non-Fiction', 'Science', 'History', 'Biography', 'Other'),
     price DECIMAL(10,2),
     page_count SMALLINT UNSIGNED,
     description TEXT,
     in_stock BOOLEAN DEFAULT TRUE,
     cover_image MEDIUMBLOB,
-    data JSON,
-    data1 JSON,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-    FOREIGN KEY (author_id) REFERENCES authors(id) ON DELETE SET NULL
+    FOREIGN KEY (author_id) REFERENCES authors(id) ON DELETE SET NULL,
+    FOREIGN KEY (category_id) REFERENCES categories(id) ON DELETE SET NULL,
+    FOREIGN KEY (sub_category_id) REFERENCES sub_categories(id) ON DELETE SET NULL
 );

--- a/db/mysqlf/mysqlf_test.go
+++ b/db/mysqlf/mysqlf_test.go
@@ -27,7 +27,7 @@ type Author struct {
 	LastName            string
 	BirthDate           *time.Time
 	Nationality         *string
-	Email               *string
+	Email               string
 	Biography           *string
 	IsActive            bool
 	Rating              *float64
@@ -41,6 +41,8 @@ type Author struct {
 type Book struct {
 	ID              int64
 	AuthorID        int64 `gofacto:"foreignKey,struct:Author"`
+	CategoryID      int64 `gofacto:"foreignKey,struct:Category,table:categories"`
+	SubCategoryID   int64 `gofacto:"foreignKey,struct:SubCategory,table:sub_categories"`
 	Title           string
 	ISBN            *string
 	PublicationDate *time.Time
@@ -54,10 +56,35 @@ type Book struct {
 	UpdatedAt       time.Time
 }
 
+type Category struct {
+	ID          int64
+	Name        string
+	AuthorID    int64 `gofacto:"foreignKey,struct:Author"`
+	Description *string
+	CreatedAt   time.Time
+	UpdatedAt   time.Time
+}
+
+type SubCategory struct {
+	ID          int64
+	CategoryID  int64 `gofacto:"foreignKey,struct:Category,table:categories"`
+	AuthorID    int64 `gofacto:"foreignKey,struct:Author"`
+	Name        string
+	Description *string
+	CreatedAt   time.Time
+	UpdatedAt   time.Time
+}
+
 type testingSuite struct {
-	db      *sql.DB
-	authorF *gofacto.Factory[Author]
-	bookF   *gofacto.Factory[Book]
+	db        *sql.DB
+	authorF   *gofacto.Factory[Author]
+	bookF     *gofacto.Factory[Book]
+	categoryF *gofacto.Factory[Category]
+}
+
+func bookBlueprint(i int) Book {
+	mockGenre := "Fiction"
+	return Book{Genre: &mockGenre}
 }
 
 func (s *testingSuite) setupSuite() {
@@ -93,7 +120,8 @@ func (s *testingSuite) setupSuite() {
 
 	// set up gofacto factories
 	s.authorF = gofacto.New(Author{}).WithDB(NewConfig(s.db))
-	s.bookF = gofacto.New(Book{}).WithDB(NewConfig(s.db))
+	s.bookF = gofacto.New(Book{}).WithDB(NewConfig(s.db)).WithBlueprint(bookBlueprint)
+	s.categoryF = gofacto.New(Category{}).WithDB(NewConfig(s.db)).WithStorageName("categories")
 }
 
 func (s *testingSuite) tearDownSuite() error {
@@ -115,9 +143,17 @@ func (s *testingSuite) tearDownTest() error {
 		return err
 	}
 
+	if _, err := s.db.Exec("DELETE FROM categories"); err != nil {
+		return err
+	}
+
+	if _, err := s.db.Exec("DELETE FROM sub_categories"); err != nil {
+		return err
+	}
+
 	s.authorF.Reset()
 	s.bookF.Reset()
-
+	s.categoryF.Reset()
 	return nil
 }
 
@@ -130,7 +166,6 @@ func (s *testingSuite) Run(t *testing.T) {
 		{"TestInsertList", s.TestInsertList},
 		{"TestWithOne", s.TestWithOne},
 		{"TestWithMany", s.TestWithMany},
-		{"TestListWithOne", s.TestListWithOne},
 	}
 
 	for _, test := range tests {
@@ -163,26 +198,9 @@ func (s *testingSuite) TestInsert(t *testing.T) {
 	}
 
 	// prepare expected data
-	stmt := "SELECT * FROM authors WHERE id = ?"
-	row := s.db.QueryRow(stmt, mockAuthor.ID)
-	var author Author
-	if err := row.Scan(
-		&author.ID,
-		&author.FirstName,
-		&author.LastName,
-		&author.BirthDate,
-		&author.Nationality,
-		&author.Email,
-		&author.Biography,
-		&author.IsActive,
-		&author.Rating,
-		&author.BooksWritten,
-		&author.LastPublicationTime,
-		&author.WebsiteURL,
-		&author.FanCount,
-		&author.ProfilePicture,
-	); err != nil {
-		t.Fatalf("Failed to scan author: %s", err)
+	author, err := findAuthor(s.db, "SELECT * FROM authors WHERE id = ?", mockAuthor.ID)
+	if err != nil {
+		t.Fatalf("Failed to find author: %s", err)
 	}
 
 	// assertion
@@ -199,36 +217,9 @@ func (s *testingSuite) TestInsertList(t *testing.T) {
 	}
 
 	// prepare expected data
-	stmt := "SELECT * FROM authors WHERE id IN (?, ?, ?)"
-	rows, err := s.db.Query(stmt, mockAuthors[0].ID, mockAuthors[1].ID, mockAuthors[2].ID)
+	authors, err := findAuthors(s.db, "SELECT * FROM authors WHERE id IN (?, ?, ?)", mockAuthors[0].ID, mockAuthors[1].ID, mockAuthors[2].ID)
 	if err != nil {
-		t.Fatalf("Failed to query authors: %s", err)
-	}
-	defer rows.Close()
-
-	var authors []Author
-	for rows.Next() {
-		var author Author
-		if err := rows.Scan(
-			&author.ID,
-			&author.FirstName,
-			&author.LastName,
-			&author.BirthDate,
-			&author.Nationality,
-			&author.Email,
-			&author.Biography,
-			&author.IsActive,
-			&author.Rating,
-			&author.BooksWritten,
-			&author.LastPublicationTime,
-			&author.WebsiteURL,
-			&author.FanCount,
-			&author.ProfilePicture,
-		); err != nil {
-			t.Fatalf("Failed to scan author: %s", err)
-		}
-
-		authors = append(authors, author)
+		t.Fatalf("Failed to find authors: %s", err)
 	}
 
 	// assertion
@@ -238,22 +229,549 @@ func (s *testingSuite) TestInsertList(t *testing.T) {
 }
 
 func (s *testingSuite) TestWithOne(t *testing.T) {
+	for _, fn := range map[string]func(*testingSuite, *testing.T){
+		"when on builder, insert with association correctly":                              withOne_OnBuilder,
+		"when on builder list, insert with association correctly":                         withOne_OnBuilderList,
+		"when on builder with multi level association, insert with association correctly": withOne_OnBuilderWithMultiLevelAssociation,
+	} {
+		t.Run(testutils.GetFunName(fn), func(t *testing.T) {
+			fn(s, t)
+			if err := s.tearDownTest(); err != nil {
+				t.Fatalf("Failed to tear down test: %s", err)
+			}
+		})
+	}
+}
+
+func withOne_OnBuilder(s *testingSuite, t *testing.T) {
 	// prepare mock data
 	mockAuthor := Author{}
-	mockGenre := "Science"
-	ow := Book{Genre: &mockGenre} // set correct enum value
-	mockBook, err := s.bookF.Build(mockCTX).Overwrite(ow).WithOne(&mockAuthor).Insert()
+	mockCategory, err := s.categoryF.Build(mockCTX).WithOne(&mockAuthor).Insert()
 	if err != nil {
 		t.Fatalf("Failed to insert: %s", err)
 	}
 
 	// prepare expected data
-	bookStmt := "SELECT * FROM books WHERE author_id = ?"
-	bookRow := s.db.QueryRow(bookStmt, mockBook.AuthorID)
+	category, err := findCategory(s.db, "SELECT * FROM categories WHERE id = ?", mockCategory.ID)
+	if err != nil {
+		t.Fatalf("Failed to find category: %s", err)
+	}
+
+	author, err := findAuthor(s.db, "SELECT * FROM authors WHERE id = ?", mockCategory.AuthorID)
+	if err != nil {
+		t.Fatalf("Failed to find author: %s", err)
+	}
+
+	// assertion
+	if err := testutils.CompareVal(mockCategory, category, "CreatedAt", "UpdatedAt"); err != nil {
+		t.Fatalf("Inserted category is not the same as the mock category: %s", err)
+	}
+
+	if err := testutils.CompareVal(mockAuthor, author, "BirthDate", "LastPublicationTime"); err != nil {
+		t.Fatalf("Inserted author is not the same as the mock author: %s", err)
+	}
+
+	// check if the association is correctly set
+	if mockCategory.AuthorID != mockAuthor.ID {
+		t.Fatalf("Inserted category author id is not the same as the mock author id: %d", mockCategory.AuthorID)
+	}
+}
+
+func withOne_OnBuilderList(s *testingSuite, t *testing.T) {
+	// prepare mock data
+	mockRating := 4.5
+	mockAuthor := Author{Rating: &mockRating}
+	mockCategories, err := s.categoryF.
+		BuildList(mockCTX, 3).
+		WithOne(&mockAuthor).
+		Insert()
+	if err != nil {
+		t.Fatalf("Failed to insert categories: %s", err)
+	}
+
+	// prepare expected data
+	categories, err := findCategories(s.db, "SELECT * FROM categories WHERE author_id = ?", mockCategories[0].AuthorID)
+	if err != nil {
+		t.Fatalf("Failed to find categories: %s", err)
+	}
+
+	author, err := findAuthor(s.db, "SELECT * FROM authors WHERE id = ?", mockCategories[0].AuthorID)
+	if err != nil {
+		t.Fatalf("Failed to find author: %s", err)
+	}
+
+	// assertion
+	if err := testutils.CompareVal(mockCategories, categories, "CreatedAt", "UpdatedAt"); err != nil {
+		t.Fatalf("Inserted categories are not the same as the mock categories: %s", err)
+	}
+
+	if err := testutils.CompareVal(mockAuthor, author, "BirthDate", "LastPublicationTime"); err != nil {
+		t.Fatalf("Inserted author is not the same as the mock author: %s", err)
+	}
+
+	// check if the association is correctly set
+	for _, c := range categories {
+		if c.AuthorID != mockAuthor.ID {
+			t.Fatalf("Inserted category author id is not the same as the mock author id: %d", c.AuthorID)
+		}
+	}
+}
+
+func withOne_OnBuilderWithMultiLevelAssociation(s *testingSuite, t *testing.T) {
+	// prepare mock data
+	mockAuthor := Author{}
+	mockCategory := Category{}
+	mockSubCategory := SubCategory{}
+
+	mockBook, err := s.bookF.
+		Build(mockCTX).
+		WithOne(&mockAuthor, &mockCategory, &mockSubCategory).
+		Insert()
+	if err != nil {
+		t.Fatalf("Failed to insert book: %s", err)
+	}
+
+	// prepare expected data
+	author, err := findAuthor(s.db, "SELECT * FROM authors WHERE id = ?", mockBook.AuthorID)
+	if err != nil {
+		t.Fatalf("Failed to find author: %s", err)
+	}
+
+	category, err := findCategory(s.db, "SELECT * FROM categories WHERE author_id = ?", mockBook.AuthorID)
+	if err != nil {
+		t.Fatalf("Failed to find category: %s", err)
+	}
+
+	subCategory, err := findSubCategory(s.db, "SELECT * FROM sub_categories WHERE author_id = ?", mockBook.AuthorID)
+	if err != nil {
+		t.Fatalf("Failed to find sub category: %s", err)
+	}
+
+	book, err := findBook(s.db, "SELECT * FROM books WHERE id = ?", mockBook.ID)
+	if err != nil {
+		t.Fatalf("Failed to find book: %s", err)
+	}
+
+	// assertion
+	if err := testutils.CompareVal(mockAuthor, author, "BirthDate", "LastPublicationTime"); err != nil {
+		t.Fatalf("Inserted author is not the same as the mock author: %s", err)
+	}
+
+	if err := testutils.CompareVal(mockCategory, category, "CreatedAt", "UpdatedAt"); err != nil {
+		t.Fatalf("Inserted category is not the same as the mock category: %s", err)
+	}
+
+	if err := testutils.CompareVal(mockSubCategory, subCategory, "CreatedAt", "UpdatedAt"); err != nil {
+		t.Fatalf("Inserted sub category is not the same as the mock sub category: %s", err)
+	}
+
+	if err := testutils.CompareVal(mockBook, book, "CreatedAt", "UpdatedAt", "PublicationDate"); err != nil {
+		t.Fatalf("Inserted book is not the same as the mock book: %s", err)
+	}
+
+	// check if the association is correctly set
+	// check book association
+	if mockBook.AuthorID != mockAuthor.ID {
+		t.Fatalf("Inserted book author id is not the same as the mock author id: %d", mockBook.AuthorID)
+	}
+	if mockBook.CategoryID != mockCategory.ID {
+		t.Fatalf("Inserted book category id is not the same as the mock category id: %d", mockBook.CategoryID)
+	}
+	if mockBook.SubCategoryID != mockSubCategory.ID {
+		t.Fatalf("Inserted book sub category id is not the same as the mock sub category id: %d", mockBook.SubCategoryID)
+	}
+
+	// check category association
+	if mockCategory.AuthorID != mockAuthor.ID {
+		t.Fatalf("Inserted category author id is not the same as the mock author id: %d", mockCategory.AuthorID)
+	}
+
+	// check sub category association
+	if mockSubCategory.AuthorID != mockAuthor.ID {
+		t.Fatalf("Inserted sub category author id is not the same as the mock author id: %d", mockSubCategory.AuthorID)
+	}
+	if mockSubCategory.CategoryID != mockCategory.ID {
+		t.Fatalf("Inserted sub category category id is not the same as the mock category id: %d", mockSubCategory.CategoryID)
+	}
+}
+
+func (s *testingSuite) TestWithMany(t *testing.T) {
+	for _, fn := range map[string]func(*testingSuite, *testing.T){
+		"when association and factory value same amount, insert with association correctly":                  withMany_AssocAndFactoryValSameAmount,
+		"when association and factory value different amount, insert with association correctly":             withMany_AssocAndFactoryValDiffAmount,
+		"when multi level association and factory value same amount, insert with association correctly":      withMany_MultiLevelSameAmount,
+		"when multi level association and factory value different amount, insert with association correctly": withMany_MultiLevelDiffAmount,
+	} {
+		t.Run(testutils.GetFunName(fn), func(t *testing.T) {
+			fn(s, t)
+			if err := s.tearDownTest(); err != nil {
+				t.Fatalf("Failed to tear down test: %s", err)
+			}
+		})
+	}
+}
+
+func withMany_AssocAndFactoryValSameAmount(s *testingSuite, t *testing.T) {
+	// prepare mock data
+	mockAuthorAmount := 3
+	mockAnyAuthors := make([]interface{}, mockAuthorAmount)
+	mockRating := 2.0
+	for i := 0; i < mockAuthorAmount; i++ {
+		mockAnyAuthors[i] = &Author{Rating: &mockRating}
+	}
+	mockCategories, err := s.categoryF.BuildList(mockCTX, 3).WithMany(mockAnyAuthors).Insert()
+	if err != nil {
+		t.Fatalf("Failed to insert categories: %s", err)
+	}
+
+	mockAuthors := make([]Author, mockAuthorAmount)
+	for i := 0; i < mockAuthorAmount; i++ {
+		mockAuthors[i] = *mockAnyAuthors[i].(*Author)
+	}
+
+	// prepare expected data
+	// loop through each data to check association connection
+	for i := 0; i < mockAuthorAmount; i++ {
+		category, err := findCategory(s.db, "SELECT * FROM categories WHERE id = ?", mockCategories[i].ID)
+		if err != nil {
+			t.Fatalf("Failed to find category: %s", err)
+		}
+
+		author, err := findAuthor(s.db, "SELECT * FROM authors WHERE id = ?", mockCategories[i].AuthorID)
+		if err != nil {
+			t.Fatalf("Failed to find author: %s", err)
+		}
+
+		// assertion
+		if err := testutils.CompareVal(mockCategories[i], category, "CreatedAt", "UpdatedAt"); err != nil {
+			t.Fatalf("Inserted category is not the same as the mock category: %s", err)
+		}
+
+		if err := testutils.CompareVal(mockAuthors[i], author, "BirthDate", "LastPublicationTime"); err != nil {
+			t.Fatalf("Inserted author is not the same as the mock author: %s", err)
+		}
+
+		// check if the association is correctly set
+		if mockCategories[i].AuthorID != mockAuthors[i].ID {
+			t.Fatalf("Inserted category author id is not the same as the mock author id: %d", mockCategories[i].AuthorID)
+		}
+	}
+}
+
+func withMany_AssocAndFactoryValDiffAmount(s *testingSuite, t *testing.T) {
+	// prepare mock data
+	mockAuthorAmount := 2
+	mockAnyAuthors := make([]interface{}, mockAuthorAmount)
+	mockRating := 2.0
+	for i := 0; i < mockAuthorAmount; i++ {
+		mockAnyAuthors[i] = &Author{Rating: &mockRating}
+	}
+	mockCategories, err := s.categoryF.BuildList(mockCTX, 3).WithMany(mockAnyAuthors).Insert()
+	if err != nil {
+		t.Fatalf("Failed to insert categories: %s", err)
+	}
+
+	mockAuthors := make([]Author, mockAuthorAmount)
+	for i := 0; i < mockAuthorAmount; i++ {
+		mockAuthors[i] = *mockAnyAuthors[i].(*Author)
+	}
+
+	// prepare expected data
+	// loop through each data to check association connection
+	for i := 0; i < 3; i++ {
+		// because we only have 2 authors, we need to loop back to the last author
+		mockAuthorIdx := i
+		if mockAuthorIdx >= mockAuthorAmount {
+			mockAuthorIdx = mockAuthorAmount - 1
+		}
+
+		category, err := findCategory(s.db, "SELECT * FROM categories WHERE id = ?", mockCategories[i].ID)
+		if err != nil {
+			t.Fatalf("Failed to find category: %s", err)
+		}
+
+		author, err := findAuthor(s.db, "SELECT * FROM authors WHERE id = ?", mockCategories[i].AuthorID)
+		if err != nil {
+			t.Fatalf("Failed to find author: %s", err)
+		}
+
+		// assertion
+		if err := testutils.CompareVal(mockCategories[i], category, "CreatedAt", "UpdatedAt"); err != nil {
+			t.Fatalf("Inserted category is not the same as the mock category: %s", err)
+		}
+
+		if err := testutils.CompareVal(mockAuthors[mockAuthorIdx], author, "BirthDate", "LastPublicationTime"); err != nil {
+			t.Fatalf("Inserted author is not the same as the mock author: %s", err)
+		}
+
+		// check if the association is correctly set
+		if mockCategories[i].AuthorID != mockAuthors[mockAuthorIdx].ID {
+			t.Fatalf("Inserted category author id is not the same as the mock author id: %d", mockCategories[i].AuthorID)
+		}
+	}
+}
+
+func withMany_MultiLevelSameAmount(s *testingSuite, t *testing.T) {
+	// prepare mock data
+	mockAuthor := make([]interface{}, 3)
+	for i := 0; i < 3; i++ {
+		mockAuthor[i] = &Author{}
+	}
+
+	mockCategory := make([]interface{}, 3)
+	for i := 0; i < 3; i++ {
+		mockCategory[i] = &Category{}
+	}
+
+	mockSubCategory := make([]interface{}, 3)
+	for i := 0; i < 3; i++ {
+		mockSubCategory[i] = &SubCategory{}
+	}
+
+	mockBooks, err := s.bookF.
+		BuildList(mockCTX, 3).
+		WithMany(mockAuthor).
+		WithMany(mockCategory).
+		WithMany(mockSubCategory).
+		Insert()
+	if err != nil {
+		t.Fatalf("Failed to insert books: %s", err)
+	}
+
+	mockAuthors := make([]Author, 3)
+	for i := 0; i < 3; i++ {
+		mockAuthors[i] = *mockAuthor[i].(*Author)
+	}
+
+	mockCategories := make([]Category, 3)
+	for i := 0; i < 3; i++ {
+		mockCategories[i] = *mockCategory[i].(*Category)
+	}
+
+	mockSubCategories := make([]SubCategory, 3)
+	for i := 0; i < 3; i++ {
+		mockSubCategories[i] = *mockSubCategory[i].(*SubCategory)
+	}
+
+	for i := 0; i < 3; i++ {
+		// prepare expected data
+		author, err := findAuthor(s.db, "SELECT * FROM authors WHERE id = ?", mockBooks[i].AuthorID)
+		if err != nil {
+			t.Fatalf("Failed to find author: %s", err)
+		}
+
+		category, err := findCategory(s.db, "SELECT * FROM categories WHERE id = ?", mockBooks[i].CategoryID)
+		if err != nil {
+			t.Fatalf("Failed to find category: %s", err)
+		}
+
+		subCategory, err := findSubCategory(s.db, "SELECT * FROM sub_categories WHERE id = ?", mockBooks[i].SubCategoryID)
+		if err != nil {
+			t.Fatalf("Failed to find sub category: %s", err)
+		}
+
+		// assertion
+		if err := testutils.CompareVal(mockAuthors[i], author, "BirthDate", "LastPublicationTime"); err != nil {
+			t.Fatalf("Inserted author is not the same as the mock author: %s", err)
+		}
+
+		if err := testutils.CompareVal(mockCategories[i], category, "CreatedAt", "UpdatedAt"); err != nil {
+			t.Fatalf("Inserted category is not the same as the mock category: %s", err)
+		}
+
+		if err := testutils.CompareVal(mockSubCategories[i], subCategory, "CreatedAt", "UpdatedAt"); err != nil {
+			t.Fatalf("Inserted sub category is not the same as the mock sub category: %s", err)
+		}
+
+		// check if the association is correctly set
+		// check book association
+		if mockBooks[i].AuthorID != mockAuthors[i].ID {
+			t.Fatalf("Inserted book author id is not the same as the mock author id: %d", mockBooks[i].AuthorID)
+		}
+		if mockBooks[i].CategoryID != mockCategories[i].ID {
+			t.Fatalf("Inserted book category id is not the same as the mock category id: %d", mockBooks[i].CategoryID)
+		}
+		if mockBooks[i].SubCategoryID != mockSubCategories[i].ID {
+			t.Fatalf("Inserted book sub category id is not the same as the mock sub category id: %d", mockBooks[i].SubCategoryID)
+		}
+
+		// check category association
+		if mockCategories[i].AuthorID != mockAuthors[i].ID {
+			t.Fatalf("Inserted category author id is not the same as the mock author id: %d", mockCategories[i].AuthorID)
+		}
+
+		// check sub category association
+		if mockSubCategories[i].AuthorID != mockAuthors[i].ID {
+			t.Fatalf("Inserted sub category author id is not the same as the mock author id: %d", mockSubCategories[i].AuthorID)
+		}
+		if mockSubCategories[i].CategoryID != mockCategories[i].ID {
+			t.Fatalf("Inserted sub category category id is not the same as the mock category id: %d", mockSubCategories[i].CategoryID)
+		}
+	}
+}
+
+func withMany_MultiLevelDiffAmount(s *testingSuite, t *testing.T) {
+	// prepare mock data
+	mockAuthorAmount := 1
+	mockAuthor := make([]interface{}, mockAuthorAmount)
+	for i := 0; i < mockAuthorAmount; i++ {
+		mockAuthor[i] = &Author{}
+	}
+
+	mockCategoryAmount := 2
+	mockCategory := make([]interface{}, mockCategoryAmount)
+	for i := 0; i < mockCategoryAmount; i++ {
+		mockCategory[i] = &Category{}
+	}
+
+	mockSubCategoryAmount := 3
+	mockSubCategory := make([]interface{}, mockSubCategoryAmount)
+	for i := 0; i < mockSubCategoryAmount; i++ {
+		mockSubCategory[i] = &SubCategory{}
+	}
+
+	mockBooks, err := s.bookF.
+		BuildList(mockCTX, 3).
+		WithMany(mockAuthor).
+		WithMany(mockCategory).
+		WithMany(mockSubCategory).
+		Insert()
+	if err != nil {
+		t.Fatalf("Failed to insert books: %s", err)
+	}
+
+	mockAuthors := make([]Author, mockAuthorAmount)
+	for i := 0; i < mockAuthorAmount; i++ {
+		mockAuthors[i] = *mockAuthor[i].(*Author)
+	}
+
+	mockCategories := make([]Category, mockCategoryAmount)
+	for i := 0; i < mockCategoryAmount; i++ {
+		mockCategories[i] = *mockCategory[i].(*Category)
+	}
+
+	mockSubCategories := make([]SubCategory, mockSubCategoryAmount)
+	for i := 0; i < mockSubCategoryAmount; i++ {
+		mockSubCategories[i] = *mockSubCategory[i].(*SubCategory)
+	}
+
+	for i := 0; i < 3; i++ {
+		mockAuthorIdx := i
+		if mockAuthorIdx >= mockAuthorAmount {
+			mockAuthorIdx = mockAuthorAmount - 1
+		}
+
+		mockCategoryIdx := i
+		if mockCategoryIdx >= mockCategoryAmount {
+			mockCategoryIdx = mockCategoryAmount - 1
+		}
+
+		mockSubCategoryIdx := i
+		if mockSubCategoryIdx >= mockSubCategoryAmount {
+			mockSubCategoryIdx = mockSubCategoryAmount - 1
+		}
+
+		// prepare expected data
+		author, err := findAuthor(s.db, "SELECT * FROM authors WHERE id = ?", mockBooks[i].AuthorID)
+		if err != nil {
+			t.Fatalf("Failed to find author: %s", err)
+		}
+
+		category, err := findCategory(s.db, "SELECT * FROM categories WHERE id = ?", mockBooks[i].CategoryID)
+		if err != nil {
+			t.Fatalf("Failed to find category: %s", err)
+		}
+
+		subCategory, err := findSubCategory(s.db, "SELECT * FROM sub_categories WHERE id = ?", mockBooks[i].SubCategoryID)
+		if err != nil {
+			t.Fatalf("Failed to find sub category: %s", err)
+		}
+
+		// assertion
+		if err := testutils.CompareVal(mockAuthors[mockAuthorIdx], author, "BirthDate", "LastPublicationTime"); err != nil {
+			t.Fatalf("Inserted author is not the same as the mock author: %s", err)
+		}
+
+		if err := testutils.CompareVal(mockCategories[mockCategoryIdx], category, "CreatedAt", "UpdatedAt"); err != nil {
+			t.Fatalf("Inserted category is not the same as the mock category: %s", err)
+		}
+
+		if err := testutils.CompareVal(mockSubCategories[mockSubCategoryIdx], subCategory, "CreatedAt", "UpdatedAt"); err != nil {
+			t.Fatalf("Inserted sub category is not the same as the mock sub category: %s", err)
+		}
+
+		// check if the association is correctly set
+		// check book association
+		if mockBooks[i].AuthorID != mockAuthors[mockAuthorIdx].ID {
+			t.Fatalf("Inserted book author id is not the same as the mock author id: %d", mockBooks[i].AuthorID)
+		}
+		if mockBooks[i].CategoryID != mockCategories[mockCategoryIdx].ID {
+			t.Fatalf("Inserted book category id is not the same as the mock category id: %d", mockBooks[i].CategoryID)
+		}
+		if mockBooks[i].SubCategoryID != mockSubCategories[mockSubCategoryIdx].ID {
+			t.Fatalf("Inserted book sub category id is not the same as the mock sub category id: %d", mockBooks[i].SubCategoryID)
+		}
+
+		// check category association
+		if mockCategories[mockCategoryIdx].AuthorID != mockAuthors[mockAuthorIdx].ID {
+			t.Fatalf("Inserted category author id is not the same as the mock author id: %d", mockCategories[mockCategoryIdx].AuthorID)
+		}
+
+		// check sub category association
+		if mockSubCategories[mockSubCategoryIdx].AuthorID != mockAuthors[mockAuthorIdx].ID {
+			t.Fatalf("Inserted sub category author id is not the same as the mock author id: %d", mockSubCategories[mockSubCategoryIdx].AuthorID)
+		}
+		if mockSubCategories[mockSubCategoryIdx].CategoryID != mockCategories[mockCategoryIdx].ID {
+			t.Fatalf("Inserted sub category category id is not the same as the mock category id: %d", mockSubCategories[i].CategoryID)
+		}
+	}
+}
+
+func findAuthor(db *sql.DB, stmt string, args ...any) (Author, error) {
+	row := db.QueryRow(stmt, args...)
+	var author Author
+	err := row.Scan(
+		&author.ID,
+		&author.FirstName,
+		&author.LastName,
+		&author.BirthDate,
+		&author.Nationality,
+		&author.Email,
+		&author.Biography,
+		&author.IsActive,
+		&author.Rating,
+		&author.BooksWritten,
+		&author.LastPublicationTime,
+		&author.WebsiteURL,
+		&author.FanCount,
+		&author.ProfilePicture,
+	)
+	return author, err
+}
+
+func findSubCategory(db *sql.DB, stmt string, args ...any) (SubCategory, error) {
+	row := db.QueryRow(stmt, args...)
+	var subCategory SubCategory
+	err := row.Scan(
+		&subCategory.ID,
+		&subCategory.CategoryID,
+		&subCategory.AuthorID,
+		&subCategory.Name,
+		&subCategory.Description,
+		&subCategory.CreatedAt,
+		&subCategory.UpdatedAt,
+	)
+	return subCategory, err
+}
+
+func findBook(db *sql.DB, stmt string, args ...any) (Book, error) {
+	row := db.QueryRow(stmt, args...)
 	var book Book
-	if err := bookRow.Scan(
+	err := row.Scan(
 		&book.ID,
 		&book.AuthorID,
+		&book.CategoryID,
+		&book.SubCategoryID,
 		&book.Title,
 		&book.ISBN,
 		&book.PublicationDate,
@@ -265,89 +783,62 @@ func (s *testingSuite) TestWithOne(t *testing.T) {
 		&book.CoverImage,
 		&book.CreatedAt,
 		&book.UpdatedAt,
-	); err != nil {
-		t.Fatalf("Failed to scan book: %s", err)
-	}
-
-	authorStmt := "SELECT * FROM authors WHERE id = ?"
-	authorRow := s.db.QueryRow(authorStmt, mockBook.AuthorID)
-	var author Author
-	if err := authorRow.Scan(
-		&author.ID,
-		&author.FirstName,
-		&author.LastName,
-		&author.BirthDate,
-		&author.Nationality,
-		&author.Email,
-		&author.Biography,
-		&author.IsActive,
-		&author.Rating,
-		&author.BooksWritten,
-		&author.LastPublicationTime,
-		&author.WebsiteURL,
-		&author.FanCount,
-		&author.ProfilePicture,
-	); err != nil {
-		t.Fatalf("Failed to scan author: %s", err)
-	}
-
-	// assertion
-	if err := testutils.CompareVal(mockBook, book, "PublicationDate", "CreatedAt", "UpdatedAt"); err != nil {
-		t.Fatalf("Inserted book is not the same as the mock book: %s", err)
-	}
-
-	if err := testutils.CompareVal(mockAuthor, author, "BirthDate", "LastPublicationTime"); err != nil {
-		t.Fatalf("Inserted author is not the same as the mock author: %s", err)
-	}
+	)
+	return book, err
 }
 
-func (s *testingSuite) TestWithMany(t *testing.T) {
-	// prepare mock data
-	mockAnyAuthors := make([]interface{}, 3)
-	for i := 0; i < 3; i++ {
-		mockAnyAuthors[i] = &Author{}
-	}
-	mockGenre := "Science"
-	ow := Book{Genre: &mockGenre} // set correct enum value
-	mockBooks, err := s.bookF.BuildList(mockCTX, 3).Overwrite(ow).WithMany(mockAnyAuthors).Insert()
+func findCategory(db *sql.DB, stmt string, args ...any) (Category, error) {
+	row := db.QueryRow(stmt, args...)
+	var category Category
+	err := row.Scan(
+		&category.ID,
+		&category.AuthorID,
+		&category.Name,
+		&category.Description,
+		&category.CreatedAt,
+		&category.UpdatedAt,
+	)
+	return category, err
+}
+
+func findCategories(db *sql.DB, stmt string, args ...any) ([]Category, error) {
+	rows, err := db.Query(stmt, args...)
 	if err != nil {
-		t.Fatalf("Failed to insert books: %s", err)
+		return nil, err
 	}
+	defer rows.Close()
 
-	mockAuthors := make([]Author, 3)
-	for i := 0; i < 3; i++ {
-		mockAuthors[i] = *mockAnyAuthors[i].(*Author)
-	}
-
-	// prepare expected data
-	bookStmt := "SELECT * FROM books WHERE author_id = ?"
-	authorStmt := "SELECT * FROM authors WHERE id = ?"
-
-	// loop through each data to check association connection
-	for i := 0; i < 3; i++ {
-		bookRow := s.db.QueryRow(bookStmt, mockBooks[i].AuthorID)
-		var book Book
-		if err := bookRow.Scan(
-			&book.ID,
-			&book.AuthorID,
-			&book.Title,
-			&book.ISBN,
-			&book.PublicationDate,
-			&book.Genre,
-			&book.Price,
-			&book.PageCount,
-			&book.Description,
-			&book.InStock,
-			&book.CoverImage,
-			&book.CreatedAt,
-			&book.UpdatedAt,
-		); err != nil {
-			t.Fatalf("Failed to scan book: %s", err)
+	var categories []Category
+	for rows.Next() {
+		var category Category
+		err := rows.Scan(
+			&category.ID,
+			&category.AuthorID,
+			&category.Name,
+			&category.Description,
+			&category.CreatedAt,
+			&category.UpdatedAt,
+		)
+		if err != nil {
+			return nil, err
 		}
+		categories = append(categories, category)
+	}
 
-		authorRow := s.db.QueryRow(authorStmt, mockBooks[i].AuthorID)
+	return categories, nil
+}
+
+func findAuthors(db *sql.DB, stmt string, args ...any) ([]Author, error) {
+	rows, err := db.Query(stmt, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var authors []Author
+	for rows.Next() {
 		var author Author
-		if err := authorRow.Scan(
+		err := rows.Scan(
 			&author.ID,
 			&author.FirstName,
 			&author.LastName,
@@ -362,90 +853,12 @@ func (s *testingSuite) TestWithMany(t *testing.T) {
 			&author.WebsiteURL,
 			&author.FanCount,
 			&author.ProfilePicture,
-		); err != nil {
-			t.Fatalf("Failed to scan author: %s", err)
+		)
+		if err != nil {
+			return nil, err
 		}
-
-		// assertion
-		if err := testutils.CompareVal(mockBooks[i], book, "PublicationDate", "CreatedAt", "UpdatedAt"); err != nil {
-			t.Fatalf("Inserted book is not the same as the mock book: %s", err)
-		}
-
-		if err := testutils.CompareVal(mockAuthors[i], author, "BirthDate", "LastPublicationTime"); err != nil {
-			t.Fatalf("Inserted author is not the same as the mock author: %s", err)
-		}
-	}
-}
-
-func (s *testingSuite) TestListWithOne(t *testing.T) {
-	// prepare mock data
-	mockAuthor := Author{}
-	mockGenre := "Science"
-	ow := Book{Genre: &mockGenre} // set correct enum value
-	mockBooks, err := s.bookF.BuildList(mockCTX, 3).Overwrite(ow).WithOne(&mockAuthor).Insert()
-	if err != nil {
-		t.Fatalf("Failed to insert books: %s", err)
+		authors = append(authors, author)
 	}
 
-	// prepare expected data
-	bookStmt := "SELECT * FROM books WHERE author_id = ?"
-	bookRows, err := s.db.Query(bookStmt, mockBooks[0].AuthorID)
-	if err != nil {
-		t.Fatalf("Failed to query books: %s", err)
-	}
-
-	var books []Book
-	for bookRows.Next() {
-		var book Book
-		if err := bookRows.Scan(
-			&book.ID,
-			&book.AuthorID,
-			&book.Title,
-			&book.ISBN,
-			&book.PublicationDate,
-			&book.Genre,
-			&book.Price,
-			&book.PageCount,
-			&book.Description,
-			&book.InStock,
-			&book.CoverImage,
-			&book.CreatedAt,
-			&book.UpdatedAt,
-		); err != nil {
-			t.Fatalf("Failed to scan book: %s", err)
-		}
-
-		books = append(books, book)
-	}
-
-	authorStmt := "SELECT * FROM authors WHERE id = ?"
-	authorRow := s.db.QueryRow(authorStmt, mockBooks[0].AuthorID)
-	var author Author
-	if err := authorRow.Scan(
-		&author.ID,
-		&author.FirstName,
-		&author.LastName,
-		&author.BirthDate,
-		&author.Nationality,
-		&author.Email,
-		&author.Biography,
-		&author.IsActive,
-		&author.Rating,
-		&author.BooksWritten,
-		&author.LastPublicationTime,
-		&author.WebsiteURL,
-		&author.FanCount,
-		&author.ProfilePicture,
-	); err != nil {
-		t.Fatalf("Failed to scan author: %s", err)
-	}
-
-	// assertion
-	if err := testutils.CompareVal(mockBooks, books, "PublicationDate", "CreatedAt", "UpdatedAt"); err != nil {
-		t.Fatalf("Inserted books are not the same as the mock books: %s", err)
-	}
-
-	if err := testutils.CompareVal(mockAuthor, author, "BirthDate", "LastPublicationTime"); err != nil {
-		t.Fatalf("Inserted author is not the same as the mock author: %s", err)
-	}
+	return authors, nil
 }

--- a/db/mysqlf/schema.sql
+++ b/db/mysqlf/schema.sql
@@ -15,9 +15,33 @@ CREATE TABLE IF NOT EXISTS authors (
     profile_picture BLOB
 );
 
+CREATE TABLE IF NOT EXISTS categories (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    author_id INT,
+    name VARCHAR(255) NOT NULL,
+    description TEXT,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    FOREIGN KEY (author_id) REFERENCES authors(id) ON DELETE SET NULL
+);
+
+CREATE TABLE IF NOT EXISTS sub_categories (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    category_id INT NOT NULL,
+    author_id INT,
+    name VARCHAR(255) NOT NULL,
+    description TEXT,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    FOREIGN KEY (category_id) REFERENCES categories(id) ON DELETE CASCADE,
+    FOREIGN KEY (author_id) REFERENCES authors(id) ON DELETE SET NULL
+);
+
 CREATE TABLE IF NOT EXISTS books (
     id INT AUTO_INCREMENT PRIMARY KEY,
     author_id INT,
+    category_id INT,
+    sub_category_id INT,
     title VARCHAR(255) NOT NULL,
     isbn CHAR(13) UNIQUE,
     publication_date DATE,
@@ -29,5 +53,7 @@ CREATE TABLE IF NOT EXISTS books (
     cover_image MEDIUMBLOB,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-    FOREIGN KEY (author_id) REFERENCES authors(id) ON DELETE SET NULL
+    FOREIGN KEY (author_id) REFERENCES authors(id) ON DELETE SET NULL,
+    FOREIGN KEY (category_id) REFERENCES categories(id) ON DELETE SET NULL,
+    FOREIGN KEY (sub_category_id) REFERENCES sub_categories(id) ON DELETE SET NULL
 );

--- a/db/postgresf/postgresf_test.go
+++ b/db/postgresf/postgresf_test.go
@@ -40,6 +40,8 @@ type Author struct {
 type Book struct {
 	ID              int64
 	AuthorID        int64 `gofacto:"foreignKey,struct:Author"`
+	CategoryID      int64 `gofacto:"foreignKey,struct:Category,table:categories"`
+	SubCategoryID   int64 `gofacto:"foreignKey,struct:SubCategory,table:sub_categories"`
 	Title           string
 	ISBN            *string
 	PublicationDate *time.Time
@@ -53,10 +55,35 @@ type Book struct {
 	UpdatedAt       time.Time
 }
 
+type Category struct {
+	ID          int64
+	Name        string
+	AuthorID    int64 `gofacto:"foreignKey,struct:Author"`
+	Description *string
+	CreatedAt   time.Time
+	UpdatedAt   time.Time
+}
+
+type SubCategory struct {
+	ID          int64
+	CategoryID  int64 `gofacto:"foreignKey,struct:Category,table:categories"`
+	AuthorID    int64 `gofacto:"foreignKey,struct:Author"`
+	Name        string
+	Description *string
+	CreatedAt   time.Time
+	UpdatedAt   time.Time
+}
+
 type testingSuite struct {
-	db      *sql.DB
-	authorF *gofacto.Factory[Author]
-	bookF   *gofacto.Factory[Book]
+	db        *sql.DB
+	authorF   *gofacto.Factory[Author]
+	bookF     *gofacto.Factory[Book]
+	categoryF *gofacto.Factory[Category]
+}
+
+func bookBlueprint(i int) Book {
+	mockGenre := "Fiction"
+	return Book{Genre: &mockGenre}
 }
 
 func (s *testingSuite) setupSuite() {
@@ -92,7 +119,8 @@ func (s *testingSuite) setupSuite() {
 
 	// Set up gofacto factories
 	s.authorF = gofacto.New(Author{}).WithDB(NewConfig(s.db))
-	s.bookF = gofacto.New(Book{}).WithDB(NewConfig(s.db))
+	s.bookF = gofacto.New(Book{}).WithDB(NewConfig(s.db)).WithBlueprint(bookBlueprint)
+	s.categoryF = gofacto.New(Category{}).WithDB(NewConfig(s.db)).WithStorageName("categories")
 }
 
 func (s *testingSuite) tearDownSuite() error {
@@ -109,12 +137,22 @@ func (s *testingSuite) tearDownTest() error {
 	if _, err := s.db.Exec("DELETE FROM authors"); err != nil {
 		return err
 	}
+
 	if _, err := s.db.Exec("DELETE FROM books"); err != nil {
+		return err
+	}
+
+	if _, err := s.db.Exec("DELETE FROM categories"); err != nil {
+		return err
+	}
+
+	if _, err := s.db.Exec("DELETE FROM sub_categories"); err != nil {
 		return err
 	}
 
 	s.authorF.Reset()
 	s.bookF.Reset()
+	s.categoryF.Reset()
 
 	return nil
 }
@@ -128,7 +166,6 @@ func (s *testingSuite) Run(t *testing.T) {
 		{"TestInsertList", s.TestInsertList},
 		{"TestWithOne", s.TestWithOne},
 		{"TestWithMany", s.TestWithMany},
-		{"TestListWithOne", s.TestListWithOne},
 	}
 
 	for _, test := range tests {
@@ -161,26 +198,9 @@ func (s *testingSuite) TestInsert(t *testing.T) {
 	}
 
 	// prepare expected data
-	stmt := "SELECT * FROM authors WHERE id = $1"
-	row := s.db.QueryRow(stmt, mockAuthor.ID)
-	var author Author
-	if err := row.Scan(
-		&author.ID,
-		&author.FirstName,
-		&author.LastName,
-		&author.BirthDate,
-		&author.Nationality,
-		&author.Email,
-		&author.Biography,
-		&author.IsActive,
-		&author.Rating,
-		&author.BooksWritten,
-		&author.LastPublicationTime,
-		&author.WebsiteURL,
-		&author.FanCount,
-		&author.ProfilePicture,
-	); err != nil {
-		t.Fatalf("Failed to scan author: %s", err)
+	author, err := findAuthor(s.db, "SELECT * FROM authors WHERE id = $1", mockAuthor.ID)
+	if err != nil {
+		t.Fatalf("Failed to find author: %s", err)
 	}
 
 	// assertion
@@ -197,36 +217,9 @@ func (s *testingSuite) TestInsertList(t *testing.T) {
 	}
 
 	// prepare expected data
-	stmt := "SELECT * FROM authors WHERE id IN ($1, $2, $3)"
-	rows, err := s.db.Query(stmt, mockAuthors[0].ID, mockAuthors[1].ID, mockAuthors[2].ID)
+	authors, err := findAuthors(s.db, "SELECT * FROM authors WHERE id IN ($1, $2, $3)", mockAuthors[0].ID, mockAuthors[1].ID, mockAuthors[2].ID)
 	if err != nil {
-		t.Fatalf("Failed to query authors: %s", err)
-	}
-	defer rows.Close()
-
-	var authors []Author
-	for rows.Next() {
-		var author Author
-		if err := rows.Scan(
-			&author.ID,
-			&author.FirstName,
-			&author.LastName,
-			&author.BirthDate,
-			&author.Nationality,
-			&author.Email,
-			&author.Biography,
-			&author.IsActive,
-			&author.Rating,
-			&author.BooksWritten,
-			&author.LastPublicationTime,
-			&author.WebsiteURL,
-			&author.FanCount,
-			&author.ProfilePicture,
-		); err != nil {
-			t.Fatalf("Failed to scan author: %s", err)
-		}
-
-		authors = append(authors, author)
+		t.Fatalf("Failed to find authors: %s", err)
 	}
 
 	// assertion
@@ -236,22 +229,553 @@ func (s *testingSuite) TestInsertList(t *testing.T) {
 }
 
 func (s *testingSuite) TestWithOne(t *testing.T) {
+	for _, fn := range map[string]func(*testingSuite, *testing.T){
+		"when on builder, insert with association correctly":                              withOne_OnBuilder,
+		"when on builder list, insert with association correctly":                         withOne_OnBuilderList,
+		"when on builder with multi level association, insert with association correctly": withOne_OnBuilderWithMultiLevelAssociation,
+	} {
+		t.Run(testutils.GetFunName(fn), func(t *testing.T) {
+			fn(s, t)
+			if err := s.tearDownTest(); err != nil {
+				t.Fatalf("Failed to tear down test: %s", err)
+			}
+		})
+	}
+}
+
+func withOne_OnBuilder(s *testingSuite, t *testing.T) {
 	// prepare mock data
 	mockAuthor := Author{}
-	mockGenre := "Science"
-	ow := Book{Genre: &mockGenre} // set correct enum value
-	mockBook, err := s.bookF.Build(mockCTX).Overwrite(ow).WithOne(&mockAuthor).Insert()
+	mockCategory, err := s.categoryF.Build(mockCTX).WithOne(&mockAuthor).Insert()
 	if err != nil {
 		t.Fatalf("Failed to insert: %s", err)
 	}
 
 	// prepare expected data
-	bookStmt := "SELECT * FROM books WHERE author_id = $1"
-	bookRow := s.db.QueryRow(bookStmt, mockBook.AuthorID)
+	category, err := findCategory(s.db, "SELECT * FROM categories WHERE id = $1", mockCategory.ID)
+	if err != nil {
+		t.Fatalf("Failed to find category: %s", err)
+	}
+
+	author, err := findAuthor(s.db, "SELECT * FROM authors WHERE id = $1", mockCategory.AuthorID)
+	if err != nil {
+		t.Fatalf("Failed to find author: %s", err)
+	}
+
+	// assertion
+	if err := testutils.CompareVal(mockCategory, category, "CreatedAt", "UpdatedAt"); err != nil {
+		t.Fatalf("Inserted category is not the same as the mock category: %s", err)
+	}
+
+	if err := testutils.CompareVal(mockAuthor, author, "BirthDate", "LastPublicationTime"); err != nil {
+		t.Fatalf("Inserted author is not the same as the mock author: %s", err)
+	}
+
+	// check if the association is correctly set
+	if mockCategory.AuthorID != mockAuthor.ID {
+		t.Fatalf("Inserted category author id is not the same as the mock author id: %d", mockCategory.AuthorID)
+	}
+}
+
+func withOne_OnBuilderList(s *testingSuite, t *testing.T) {
+	// prepare mock data
+	mockRating := 4.5
+	mockAuthor := Author{Rating: &mockRating}
+	mockCategories, err := s.categoryF.
+		BuildList(mockCTX, 3).
+		WithOne(&mockAuthor).
+		Insert()
+	if err != nil {
+		t.Fatalf("Failed to insert categories: %s", err)
+	}
+
+	// prepare expected data
+	categories, err := findCategories(s.db, "SELECT * FROM categories WHERE author_id = $1", mockCategories[0].AuthorID)
+	if err != nil {
+		t.Fatalf("Failed to find categories: %s", err)
+	}
+
+	author, err := findAuthor(s.db, "SELECT * FROM authors WHERE id = $1", mockCategories[0].AuthorID)
+	if err != nil {
+		t.Fatalf("Failed to find author: %s", err)
+	}
+
+	// assertion
+	if err := testutils.CompareVal(mockCategories, categories, "CreatedAt", "UpdatedAt"); err != nil {
+		t.Fatalf("Inserted categories are not the same as the mock categories: %s", err)
+	}
+
+	if err := testutils.CompareVal(mockAuthor, author, "BirthDate", "LastPublicationTime"); err != nil {
+		t.Fatalf("Inserted author is not the same as the mock author: %s", err)
+	}
+
+	// check if the association is correctly set
+	for _, c := range categories {
+		if c.AuthorID != mockAuthor.ID {
+			t.Fatalf("Inserted category author id is not the same as the mock author id: %d", c.AuthorID)
+		}
+	}
+}
+
+func withOne_OnBuilderWithMultiLevelAssociation(s *testingSuite, t *testing.T) {
+	// prepare mock data
+	mockAuthor := Author{}
+	mockCategory := Category{}
+	mockSubCategory := SubCategory{}
+
+	mockBook, err := s.bookF.
+		Build(mockCTX).
+		WithOne(&mockAuthor, &mockCategory, &mockSubCategory).
+		Insert()
+	if err != nil {
+		t.Fatalf("Failed to insert book: %s", err)
+	}
+
+	// prepare expected data
+	author, err := findAuthor(s.db, "SELECT * FROM authors WHERE id = $1", mockBook.AuthorID)
+	if err != nil {
+		t.Fatalf("Failed to find author: %s", err)
+	}
+
+	category, err := findCategory(s.db, "SELECT * FROM categories WHERE author_id = $1", mockBook.AuthorID)
+	if err != nil {
+		t.Fatalf("Failed to find category: %s", err)
+	}
+
+	subCategory, err := findSubCategory(s.db, "SELECT * FROM sub_categories WHERE author_id = $1", mockBook.AuthorID)
+	if err != nil {
+		t.Fatalf("Failed to find sub category: %s", err)
+	}
+
+	book, err := findBook(s.db, "SELECT * FROM books WHERE id = $1", mockBook.ID)
+	if err != nil {
+		t.Fatalf("Failed to find book: %s", err)
+	}
+
+	// assertion
+	if err := testutils.CompareVal(mockAuthor, author, "BirthDate", "LastPublicationTime"); err != nil {
+		t.Fatalf("Inserted author is not the same as the mock author: %s", err)
+	}
+
+	if err := testutils.CompareVal(mockCategory, category, "CreatedAt", "UpdatedAt"); err != nil {
+		t.Fatalf("Inserted category is not the same as the mock category: %s", err)
+	}
+
+	if err := testutils.CompareVal(mockSubCategory, subCategory, "CreatedAt", "UpdatedAt"); err != nil {
+		t.Fatalf("Inserted sub category is not the same as the mock sub category: %s", err)
+	}
+
+	// trim the value of CHAR(13)
+	// when selecting the value of CHAR(13) from postgres, it will include the padding space
+	trimStr := strings.TrimSpace(*book.ISBN)
+	book.ISBN = &trimStr
+	if err := testutils.CompareVal(mockBook, book, "CreatedAt", "UpdatedAt", "PublicationDate"); err != nil {
+		t.Fatalf("Inserted book is not the same as the mock book: %s", err)
+	}
+
+	// check if the association is correctly set
+	// check book association
+	if mockBook.AuthorID != mockAuthor.ID {
+		t.Fatalf("Inserted book author id is not the same as the mock author id: %d", mockBook.AuthorID)
+	}
+	if mockBook.CategoryID != mockCategory.ID {
+		t.Fatalf("Inserted book category id is not the same as the mock category id: %d", mockBook.CategoryID)
+	}
+	if mockBook.SubCategoryID != mockSubCategory.ID {
+		t.Fatalf("Inserted book sub category id is not the same as the mock sub category id: %d", mockBook.SubCategoryID)
+	}
+
+	// check category association
+	if mockCategory.AuthorID != mockAuthor.ID {
+		t.Fatalf("Inserted category author id is not the same as the mock author id: %d", mockCategory.AuthorID)
+	}
+
+	// check sub category association
+	if mockSubCategory.AuthorID != mockAuthor.ID {
+		t.Fatalf("Inserted sub category author id is not the same as the mock author id: %d", mockSubCategory.AuthorID)
+	}
+	if mockSubCategory.CategoryID != mockCategory.ID {
+		t.Fatalf("Inserted sub category category id is not the same as the mock category id: %d", mockSubCategory.CategoryID)
+	}
+}
+
+func (s *testingSuite) TestWithMany(t *testing.T) {
+	for _, fn := range map[string]func(*testingSuite, *testing.T){
+		"when association and factory value same amount, insert with association correctly":                  withMany_AssocAndFactoryValSameAmount,
+		"when association and factory value different amount, insert with association correctly":             withMany_AssocAndFactoryValDiffAmount,
+		"when multi level association and factory value same amount, insert with association correctly":      withMany_MultiLevelSameAmount,
+		"when multi level association and factory value different amount, insert with association correctly": withMany_MultiLevelDiffAmount,
+	} {
+		t.Run(testutils.GetFunName(fn), func(t *testing.T) {
+			fn(s, t)
+			if err := s.tearDownTest(); err != nil {
+				t.Fatalf("Failed to tear down test: %s", err)
+			}
+		})
+	}
+}
+
+func withMany_AssocAndFactoryValSameAmount(s *testingSuite, t *testing.T) {
+	// prepare mock data
+	mockAuthorAmount := 3
+	mockAnyAuthors := make([]interface{}, mockAuthorAmount)
+	mockRating := 2.0
+	for i := 0; i < mockAuthorAmount; i++ {
+		mockAnyAuthors[i] = &Author{Rating: &mockRating}
+	}
+	mockCategories, err := s.categoryF.BuildList(mockCTX, 3).WithMany(mockAnyAuthors).Insert()
+	if err != nil {
+		t.Fatalf("Failed to insert categories: %s", err)
+	}
+
+	mockAuthors := make([]Author, mockAuthorAmount)
+	for i := 0; i < mockAuthorAmount; i++ {
+		mockAuthors[i] = *mockAnyAuthors[i].(*Author)
+	}
+
+	// prepare expected data
+	// loop through each data to check association connection
+	for i := 0; i < mockAuthorAmount; i++ {
+		category, err := findCategory(s.db, "SELECT * FROM categories WHERE id = $1", mockCategories[i].ID)
+		if err != nil {
+			t.Fatalf("Failed to find category: %s", err)
+		}
+
+		author, err := findAuthor(s.db, "SELECT * FROM authors WHERE id = $1", mockCategories[i].AuthorID)
+		if err != nil {
+			t.Fatalf("Failed to find author: %s", err)
+		}
+
+		// assertion
+		if err := testutils.CompareVal(mockCategories[i], category, "CreatedAt", "UpdatedAt"); err != nil {
+			t.Fatalf("Inserted category is not the same as the mock category: %s", err)
+		}
+
+		if err := testutils.CompareVal(mockAuthors[i], author, "BirthDate", "LastPublicationTime"); err != nil {
+			t.Fatalf("Inserted author is not the same as the mock author: %s", err)
+		}
+
+		// check if the association is correctly set
+		if mockCategories[i].AuthorID != mockAuthors[i].ID {
+			t.Fatalf("Inserted category author id is not the same as the mock author id: %d", mockCategories[i].AuthorID)
+		}
+	}
+}
+
+func withMany_AssocAndFactoryValDiffAmount(s *testingSuite, t *testing.T) {
+	// prepare mock data
+	mockAuthorAmount := 2
+	mockAnyAuthors := make([]interface{}, mockAuthorAmount)
+	mockRating := 2.0
+	for i := 0; i < mockAuthorAmount; i++ {
+		mockAnyAuthors[i] = &Author{Rating: &mockRating}
+	}
+	mockCategories, err := s.categoryF.BuildList(mockCTX, 3).WithMany(mockAnyAuthors).Insert()
+	if err != nil {
+		t.Fatalf("Failed to insert categories: %s", err)
+	}
+
+	mockAuthors := make([]Author, mockAuthorAmount)
+	for i := 0; i < mockAuthorAmount; i++ {
+		mockAuthors[i] = *mockAnyAuthors[i].(*Author)
+	}
+
+	// prepare expected data
+	// loop through each data to check association connection
+	for i := 0; i < 3; i++ {
+		// because we only have 2 authors, we need to loop back to the last author
+		mockAuthorIdx := i
+		if mockAuthorIdx >= mockAuthorAmount {
+			mockAuthorIdx = mockAuthorAmount - 1
+		}
+
+		category, err := findCategory(s.db, "SELECT * FROM categories WHERE id = $1", mockCategories[i].ID)
+		if err != nil {
+			t.Fatalf("Failed to find category: %s", err)
+		}
+
+		author, err := findAuthor(s.db, "SELECT * FROM authors WHERE id = $1", mockCategories[i].AuthorID)
+		if err != nil {
+			t.Fatalf("Failed to find author: %s", err)
+		}
+
+		// assertion
+		if err := testutils.CompareVal(mockCategories[i], category, "CreatedAt", "UpdatedAt"); err != nil {
+			t.Fatalf("Inserted category is not the same as the mock category: %s", err)
+		}
+
+		if err := testutils.CompareVal(mockAuthors[mockAuthorIdx], author, "BirthDate", "LastPublicationTime"); err != nil {
+			t.Fatalf("Inserted author is not the same as the mock author: %s", err)
+		}
+
+		// check if the association is correctly set
+		if mockCategories[i].AuthorID != mockAuthors[mockAuthorIdx].ID {
+			t.Fatalf("Inserted category author id is not the same as the mock author id: %d", mockCategories[i].AuthorID)
+		}
+	}
+}
+
+func withMany_MultiLevelSameAmount(s *testingSuite, t *testing.T) {
+	// prepare mock data
+	mockAuthor := make([]interface{}, 3)
+	for i := 0; i < 3; i++ {
+		mockAuthor[i] = &Author{}
+	}
+
+	mockCategory := make([]interface{}, 3)
+	for i := 0; i < 3; i++ {
+		mockCategory[i] = &Category{}
+	}
+
+	mockSubCategory := make([]interface{}, 3)
+	for i := 0; i < 3; i++ {
+		mockSubCategory[i] = &SubCategory{}
+	}
+
+	mockBooks, err := s.bookF.
+		BuildList(mockCTX, 3).
+		WithMany(mockAuthor).
+		WithMany(mockCategory).
+		WithMany(mockSubCategory).
+		Insert()
+	if err != nil {
+		t.Fatalf("Failed to insert books: %s", err)
+	}
+
+	mockAuthors := make([]Author, 3)
+	for i := 0; i < 3; i++ {
+		mockAuthors[i] = *mockAuthor[i].(*Author)
+	}
+
+	mockCategories := make([]Category, 3)
+	for i := 0; i < 3; i++ {
+		mockCategories[i] = *mockCategory[i].(*Category)
+	}
+
+	mockSubCategories := make([]SubCategory, 3)
+	for i := 0; i < 3; i++ {
+		mockSubCategories[i] = *mockSubCategory[i].(*SubCategory)
+	}
+
+	for i := 0; i < 3; i++ {
+		// prepare expected data
+		author, err := findAuthor(s.db, "SELECT * FROM authors WHERE id = $1", mockBooks[i].AuthorID)
+		if err != nil {
+			t.Fatalf("Failed to find author: %s", err)
+		}
+
+		category, err := findCategory(s.db, "SELECT * FROM categories WHERE id = $1", mockBooks[i].CategoryID)
+		if err != nil {
+			t.Fatalf("Failed to find category: %s", err)
+		}
+
+		subCategory, err := findSubCategory(s.db, "SELECT * FROM sub_categories WHERE id = $1", mockBooks[i].SubCategoryID)
+		if err != nil {
+			t.Fatalf("Failed to find sub category: %s", err)
+		}
+
+		// assertion
+		if err := testutils.CompareVal(mockAuthors[i], author, "BirthDate", "LastPublicationTime"); err != nil {
+			t.Fatalf("Inserted author is not the same as the mock author: %s", err)
+		}
+
+		if err := testutils.CompareVal(mockCategories[i], category, "CreatedAt", "UpdatedAt"); err != nil {
+			t.Fatalf("Inserted category is not the same as the mock category: %s", err)
+		}
+
+		if err := testutils.CompareVal(mockSubCategories[i], subCategory, "CreatedAt", "UpdatedAt"); err != nil {
+			t.Fatalf("Inserted sub category is not the same as the mock sub category: %s", err)
+		}
+
+		// check if the association is correctly set
+		// check book association
+		if mockBooks[i].AuthorID != mockAuthors[i].ID {
+			t.Fatalf("Inserted book author id is not the same as the mock author id: %d", mockBooks[i].AuthorID)
+		}
+		if mockBooks[i].CategoryID != mockCategories[i].ID {
+			t.Fatalf("Inserted book category id is not the same as the mock category id: %d", mockBooks[i].CategoryID)
+		}
+		if mockBooks[i].SubCategoryID != mockSubCategories[i].ID {
+			t.Fatalf("Inserted book sub category id is not the same as the mock sub category id: %d", mockBooks[i].SubCategoryID)
+		}
+
+		// check category association
+		if mockCategories[i].AuthorID != mockAuthors[i].ID {
+			t.Fatalf("Inserted category author id is not the same as the mock author id: %d", mockCategories[i].AuthorID)
+		}
+
+		// check sub category association
+		if mockSubCategories[i].AuthorID != mockAuthors[i].ID {
+			t.Fatalf("Inserted sub category author id is not the same as the mock author id: %d", mockSubCategories[i].AuthorID)
+		}
+		if mockSubCategories[i].CategoryID != mockCategories[i].ID {
+			t.Fatalf("Inserted sub category category id is not the same as the mock category id: %d", mockSubCategories[i].CategoryID)
+		}
+	}
+}
+
+func withMany_MultiLevelDiffAmount(s *testingSuite, t *testing.T) {
+	// prepare mock data
+	mockAuthorAmount := 1
+	mockAuthor := make([]interface{}, mockAuthorAmount)
+	for i := 0; i < mockAuthorAmount; i++ {
+		mockAuthor[i] = &Author{}
+	}
+
+	mockCategoryAmount := 2
+	mockCategory := make([]interface{}, mockCategoryAmount)
+	for i := 0; i < mockCategoryAmount; i++ {
+		mockCategory[i] = &Category{}
+	}
+
+	mockSubCategoryAmount := 3
+	mockSubCategory := make([]interface{}, mockSubCategoryAmount)
+	for i := 0; i < mockSubCategoryAmount; i++ {
+		mockSubCategory[i] = &SubCategory{}
+	}
+
+	mockBooks, err := s.bookF.
+		BuildList(mockCTX, 3).
+		WithMany(mockAuthor).
+		WithMany(mockCategory).
+		WithMany(mockSubCategory).
+		Insert()
+	if err != nil {
+		t.Fatalf("Failed to insert books: %s", err)
+	}
+
+	mockAuthors := make([]Author, mockAuthorAmount)
+	for i := 0; i < mockAuthorAmount; i++ {
+		mockAuthors[i] = *mockAuthor[i].(*Author)
+	}
+
+	mockCategories := make([]Category, mockCategoryAmount)
+	for i := 0; i < mockCategoryAmount; i++ {
+		mockCategories[i] = *mockCategory[i].(*Category)
+	}
+
+	mockSubCategories := make([]SubCategory, mockSubCategoryAmount)
+	for i := 0; i < mockSubCategoryAmount; i++ {
+		mockSubCategories[i] = *mockSubCategory[i].(*SubCategory)
+	}
+
+	for i := 0; i < 3; i++ {
+		mockAuthorIdx := i
+		if mockAuthorIdx >= mockAuthorAmount {
+			mockAuthorIdx = mockAuthorAmount - 1
+		}
+
+		mockCategoryIdx := i
+		if mockCategoryIdx >= mockCategoryAmount {
+			mockCategoryIdx = mockCategoryAmount - 1
+		}
+
+		mockSubCategoryIdx := i
+		if mockSubCategoryIdx >= mockSubCategoryAmount {
+			mockSubCategoryIdx = mockSubCategoryAmount - 1
+		}
+
+		// prepare expected data
+		author, err := findAuthor(s.db, "SELECT * FROM authors WHERE id = $1", mockBooks[i].AuthorID)
+		if err != nil {
+			t.Fatalf("Failed to find author: %s", err)
+		}
+
+		category, err := findCategory(s.db, "SELECT * FROM categories WHERE id = $1", mockBooks[i].CategoryID)
+		if err != nil {
+			t.Fatalf("Failed to find category: %s", err)
+		}
+
+		subCategory, err := findSubCategory(s.db, "SELECT * FROM sub_categories WHERE id = $1", mockBooks[i].SubCategoryID)
+		if err != nil {
+			t.Fatalf("Failed to find sub category: %s", err)
+		}
+
+		// assertion
+		if err := testutils.CompareVal(mockAuthors[mockAuthorIdx], author, "BirthDate", "LastPublicationTime"); err != nil {
+			t.Fatalf("Inserted author is not the same as the mock author: %s", err)
+		}
+
+		if err := testutils.CompareVal(mockCategories[mockCategoryIdx], category, "CreatedAt", "UpdatedAt"); err != nil {
+			t.Fatalf("Inserted category is not the same as the mock category: %s", err)
+		}
+
+		if err := testutils.CompareVal(mockSubCategories[mockSubCategoryIdx], subCategory, "CreatedAt", "UpdatedAt"); err != nil {
+			t.Fatalf("Inserted sub category is not the same as the mock sub category: %s", err)
+		}
+
+		// check if the association is correctly set
+		// check book association
+		if mockBooks[i].AuthorID != mockAuthors[mockAuthorIdx].ID {
+			t.Fatalf("Inserted book author id is not the same as the mock author id: %d", mockBooks[i].AuthorID)
+		}
+		if mockBooks[i].CategoryID != mockCategories[mockCategoryIdx].ID {
+			t.Fatalf("Inserted book category id is not the same as the mock category id: %d", mockBooks[i].CategoryID)
+		}
+		if mockBooks[i].SubCategoryID != mockSubCategories[mockSubCategoryIdx].ID {
+			t.Fatalf("Inserted book sub category id is not the same as the mock sub category id: %d", mockBooks[i].SubCategoryID)
+		}
+
+		// check category association
+		if mockCategories[mockCategoryIdx].AuthorID != mockAuthors[mockAuthorIdx].ID {
+			t.Fatalf("Inserted category author id is not the same as the mock author id: %d", mockCategories[mockCategoryIdx].AuthorID)
+		}
+
+		// check sub category association
+		if mockSubCategories[mockSubCategoryIdx].AuthorID != mockAuthors[mockAuthorIdx].ID {
+			t.Fatalf("Inserted sub category author id is not the same as the mock author id: %d", mockSubCategories[mockSubCategoryIdx].AuthorID)
+		}
+		if mockSubCategories[mockSubCategoryIdx].CategoryID != mockCategories[mockCategoryIdx].ID {
+			t.Fatalf("Inserted sub category category id is not the same as the mock category id: %d", mockSubCategories[i].CategoryID)
+		}
+	}
+}
+
+func findAuthor(db *sql.DB, stmt string, args ...any) (Author, error) {
+	row := db.QueryRow(stmt, args...)
+	var author Author
+	err := row.Scan(
+		&author.ID,
+		&author.FirstName,
+		&author.LastName,
+		&author.BirthDate,
+		&author.Nationality,
+		&author.Email,
+		&author.Biography,
+		&author.IsActive,
+		&author.Rating,
+		&author.BooksWritten,
+		&author.LastPublicationTime,
+		&author.WebsiteURL,
+		&author.FanCount,
+		&author.ProfilePicture,
+	)
+	return author, err
+}
+
+func findSubCategory(db *sql.DB, stmt string, args ...any) (SubCategory, error) {
+	row := db.QueryRow(stmt, args...)
+	var subCategory SubCategory
+	err := row.Scan(
+		&subCategory.ID,
+		&subCategory.CategoryID,
+		&subCategory.AuthorID,
+		&subCategory.Name,
+		&subCategory.Description,
+		&subCategory.CreatedAt,
+		&subCategory.UpdatedAt,
+	)
+	return subCategory, err
+}
+
+func findBook(db *sql.DB, stmt string, args ...any) (Book, error) {
+	row := db.QueryRow(stmt, args...)
 	var book Book
-	if err := bookRow.Scan(
+	err := row.Scan(
 		&book.ID,
 		&book.AuthorID,
+		&book.CategoryID,
+		&book.SubCategoryID,
 		&book.Title,
 		&book.ISBN,
 		&book.PublicationDate,
@@ -263,99 +787,62 @@ func (s *testingSuite) TestWithOne(t *testing.T) {
 		&book.CoverImage,
 		&book.CreatedAt,
 		&book.UpdatedAt,
-	); err != nil {
-		t.Fatalf("Failed to scan book: %s", err)
-	}
-
-	// trim the value of CHAR(13)
-	// when selecting the value of CHAR(13) from postgres, it will include the padding space
-	trimStr := strings.TrimSpace(*book.ISBN)
-	book.ISBN = &trimStr
-
-	authorStmt := "SELECT * FROM authors WHERE id = $1"
-	authorRow := s.db.QueryRow(authorStmt, mockBook.AuthorID)
-	var author Author
-	if err := authorRow.Scan(
-		&author.ID,
-		&author.FirstName,
-		&author.LastName,
-		&author.BirthDate,
-		&author.Nationality,
-		&author.Email,
-		&author.Biography,
-		&author.IsActive,
-		&author.Rating,
-		&author.BooksWritten,
-		&author.LastPublicationTime,
-		&author.WebsiteURL,
-		&author.FanCount,
-		&author.ProfilePicture,
-	); err != nil {
-		t.Fatalf("Failed to scan author: %s", err)
-	}
-
-	// assertion
-	if err := testutils.CompareVal(mockBook, book, "PublicationDate", "CreatedAt", "UpdatedAt"); err != nil {
-		t.Fatalf("Inserted book is not the same as the mock book: %s", err)
-	}
-
-	if err := testutils.CompareVal(mockAuthor, author, "BirthDate", "LastPublicationTime"); err != nil {
-		t.Fatalf("Inserted author is not the same as the mock author: %s", err)
-	}
+	)
+	return book, err
 }
 
-func (s *testingSuite) TestWithMany(t *testing.T) {
-	// prepare mock data
-	mockAnyAuthors := make([]interface{}, 3)
-	for i := 0; i < 3; i++ {
-		mockAnyAuthors[i] = &Author{}
-	}
-	mockGenre := "Science"
-	ow := Book{Genre: &mockGenre} // set correct enum value
-	mockBooks, err := s.bookF.BuildList(mockCTX, 3).Overwrite(ow).WithMany(mockAnyAuthors).Insert()
+func findCategory(db *sql.DB, stmt string, args ...any) (Category, error) {
+	row := db.QueryRow(stmt, args...)
+	var category Category
+	err := row.Scan(
+		&category.ID,
+		&category.AuthorID,
+		&category.Name,
+		&category.Description,
+		&category.CreatedAt,
+		&category.UpdatedAt,
+	)
+	return category, err
+}
+
+func findCategories(db *sql.DB, stmt string, args ...any) ([]Category, error) {
+	rows, err := db.Query(stmt, args...)
 	if err != nil {
-		t.Fatalf("Failed to insert books: %s", err)
+		return nil, err
 	}
+	defer rows.Close()
 
-	mockAuthors := make([]Author, 3)
-	for i := 0; i < 3; i++ {
-		mockAuthors[i] = *mockAnyAuthors[i].(*Author)
-	}
-
-	// prepare expected data
-	bookStmt := "SELECT * FROM books WHERE author_id = $1"
-	authorStmt := "SELECT * FROM authors WHERE id = $1"
-
-	// loop through each data to check association connection
-	for i := 0; i < 3; i++ {
-		bookRow := s.db.QueryRow(bookStmt, mockBooks[i].AuthorID)
-		var book Book
-		if err := bookRow.Scan(
-			&book.ID,
-			&book.AuthorID,
-			&book.Title,
-			&book.ISBN,
-			&book.PublicationDate,
-			&book.Genre,
-			&book.Price,
-			&book.PageCount,
-			&book.Description,
-			&book.InStock,
-			&book.CoverImage,
-			&book.CreatedAt,
-			&book.UpdatedAt,
-		); err != nil {
-			t.Fatalf("Failed to scan book: %s", err)
+	var categories []Category
+	for rows.Next() {
+		var category Category
+		err := rows.Scan(
+			&category.ID,
+			&category.AuthorID,
+			&category.Name,
+			&category.Description,
+			&category.CreatedAt,
+			&category.UpdatedAt,
+		)
+		if err != nil {
+			return nil, err
 		}
+		categories = append(categories, category)
+	}
 
-		// trim the value of CHAR(13)
-		// when selecting the value of CHAR(13) from postgres, it will include the padding space
-		trimStr := strings.TrimSpace(*book.ISBN)
-		book.ISBN = &trimStr
+	return categories, nil
+}
 
-		authorRow := s.db.QueryRow(authorStmt, mockBooks[i].AuthorID)
+func findAuthors(db *sql.DB, stmt string, args ...any) ([]Author, error) {
+	rows, err := db.Query(stmt, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var authors []Author
+	for rows.Next() {
 		var author Author
-		if err := authorRow.Scan(
+		err := rows.Scan(
 			&author.ID,
 			&author.FirstName,
 			&author.LastName,
@@ -370,95 +857,12 @@ func (s *testingSuite) TestWithMany(t *testing.T) {
 			&author.WebsiteURL,
 			&author.FanCount,
 			&author.ProfilePicture,
-		); err != nil {
-			t.Fatalf("Failed to scan author: %s", err)
+		)
+		if err != nil {
+			return nil, err
 		}
-
-		// assertion
-		if err := testutils.CompareVal(mockBooks[i], book, "PublicationDate", "CreatedAt", "UpdatedAt"); err != nil {
-			t.Fatalf("Inserted book is not the same as the mock book: %s", err)
-		}
-
-		if err := testutils.CompareVal(mockAuthors[i], author, "BirthDate", "LastPublicationTime"); err != nil {
-			t.Fatalf("Inserted author is not the same as the mock author: %s", err)
-		}
-	}
-}
-
-func (s *testingSuite) TestListWithOne(t *testing.T) {
-	// prepare mock data
-	mockAuthor := Author{}
-	mockGenre := "Science"
-	ow := Book{Genre: &mockGenre} // set correct enum value
-	mockBooks, err := s.bookF.BuildList(mockCTX, 3).Overwrite(ow).WithOne(&mockAuthor).Insert()
-	if err != nil {
-		t.Fatalf("Failed to insert books: %s", err)
+		authors = append(authors, author)
 	}
 
-	// verify the inserted data
-	bookStmt := "SELECT * FROM books WHERE author_id = $1"
-	bookRows, err := s.db.Query(bookStmt, mockBooks[0].AuthorID)
-	if err != nil {
-		t.Fatalf("Failed to query books: %s", err)
-	}
-
-	var books []Book
-	for bookRows.Next() {
-		var book Book
-		if err := bookRows.Scan(
-			&book.ID,
-			&book.AuthorID,
-			&book.Title,
-			&book.ISBN,
-			&book.PublicationDate,
-			&book.Genre,
-			&book.Price,
-			&book.PageCount,
-			&book.Description,
-			&book.InStock,
-			&book.CoverImage,
-			&book.CreatedAt,
-			&book.UpdatedAt,
-		); err != nil {
-			t.Fatalf("Failed to scan book: %s", err)
-		}
-
-		// trim the value of CHAR(13)
-		// when selecting the value of CHAR(13) from postgres, it will include the padding space
-		trimStr := strings.TrimSpace(*book.ISBN)
-		book.ISBN = &trimStr
-
-		books = append(books, book)
-	}
-
-	authorStmt := "SELECT * FROM authors WHERE id = $1"
-	authorRow := s.db.QueryRow(authorStmt, mockBooks[0].AuthorID)
-	var author Author
-	if err := authorRow.Scan(
-		&author.ID,
-		&author.FirstName,
-		&author.LastName,
-		&author.BirthDate,
-		&author.Nationality,
-		&author.Email,
-		&author.Biography,
-		&author.IsActive,
-		&author.Rating,
-		&author.BooksWritten,
-		&author.LastPublicationTime,
-		&author.WebsiteURL,
-		&author.FanCount,
-		&author.ProfilePicture,
-	); err != nil {
-		t.Fatalf("Failed to scan author: %s", err)
-	}
-
-	// assertion
-	if err := testutils.CompareVal(mockBooks, books, "PublicationDate", "CreatedAt", "UpdatedAt"); err != nil {
-		t.Fatalf("Inserted books are not the same as the mock books: %s", err)
-	}
-
-	if err := testutils.CompareVal(mockAuthor, author, "BirthDate", "LastPublicationTime"); err != nil {
-		t.Fatalf("Inserted author is not the same as the mock author: %s", err)
-	}
+	return authors, nil
 }

--- a/db/postgresf/schema.sql
+++ b/db/postgresf/schema.sql
@@ -15,9 +15,33 @@ CREATE TABLE IF NOT EXISTS authors (
     profile_picture BYTEA
 );
 
+CREATE TABLE IF NOT EXISTS categories (
+    id SERIAL PRIMARY KEY,
+    author_id INTEGER,
+    name VARCHAR(255) NOT NULL,
+    description TEXT,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (author_id) REFERENCES authors(id) ON DELETE SET NULL
+);
+
+CREATE TABLE IF NOT EXISTS sub_categories (
+    id SERIAL PRIMARY KEY,
+    category_id INTEGER NOT NULL,
+    author_id INTEGER,
+    name VARCHAR(255) NOT NULL,
+    description TEXT,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (category_id) REFERENCES categories(id) ON DELETE CASCADE,
+    FOREIGN KEY (author_id) REFERENCES authors(id) ON DELETE SET NULL
+);
+
 CREATE TABLE IF NOT EXISTS books (
     id SERIAL PRIMARY KEY,
     author_id INTEGER,
+    category_id INTEGER,
+    sub_category_id INTEGER,
     title VARCHAR(255) NOT NULL,
     isbn CHAR(13) UNIQUE,
     publication_date DATE,
@@ -29,5 +53,7 @@ CREATE TABLE IF NOT EXISTS books (
     cover_image BYTEA,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-    FOREIGN KEY (author_id) REFERENCES authors(id) ON DELETE SET NULL
+    FOREIGN KEY (author_id) REFERENCES authors(id) ON DELETE SET NULL,
+    FOREIGN KEY (category_id) REFERENCES categories(id) ON DELETE SET NULL,
+    FOREIGN KEY (sub_category_id) REFERENCES sub_categories(id) ON DELETE SET NULL
 );

--- a/err.go
+++ b/err.go
@@ -35,9 +35,6 @@ var (
 	// errTagFormat is the error representing that tag is in wrong format
 	errTagFormat = errors.New("tag is in wrong format")
 
-	// errNotFoundAtTag is the error representing that not found at tag
-	errNotFoundAtTag = errors.New("not found at tag")
-
 	// errIsNotPtr is the error representing that is not pointer
 	errIsNotPtr = errors.New("is not pointer")
 
@@ -55,4 +52,7 @@ var (
 
 	// errNotInt is the error representing that not an integer
 	errNotInt = errors.New("not an integer")
+
+	// errCycleDependency is the error representing that there is a cycle dependency
+	errCycleDependency = errors.New("cycle dependency")
 )

--- a/gofacto.go
+++ b/gofacto.go
@@ -24,13 +24,8 @@ type Factory[T any] struct {
 	// map from name to trait function
 	traits map[string]setTraiter[T]
 
-	// map from name to list of associations
-	// e.g. "User" -> []*User
-	associations map[string][]interface{}
-
-	// map from tag to metadata
-	// e.g. "User" -> {tableName: "users", fieldName: "UserID"}
-	tagToInfo map[string]tagInfo
+	// associations is a list of associations
+	associations [][]interface{}
 }
 
 // blueprintFunc is a client-defined function to create a new value
@@ -38,13 +33,6 @@ type blueprintFunc[T any] func(i int) T
 
 // setTraiter is a client-defined function to add a trait to mutate the value
 type setTraiter[T any] func(v *T)
-
-// tagInfo is the metadata for the tag
-type tagInfo struct {
-	tableName    string
-	fieldName    string
-	foreignField string
-}
 
 // builder is for building a single value
 type builder[T any] struct {
@@ -72,7 +60,7 @@ func New[T any](v T) *Factory[T] {
 		}
 	}
 
-	ti, ifd, err := extractTag(dataType)
+	ifd, err := extractTag(dataType)
 	if err != nil {
 		return &Factory[T]{
 			err: err,
@@ -82,9 +70,8 @@ func New[T any](v T) *Factory[T] {
 	return &Factory[T]{
 		dataType:       dataType,
 		empty:          reflect.New(dataType).Elem().Interface().(T),
-		associations:   map[string][]interface{}{},
+		associations:   [][]interface{}{},
 		storageName:    fmt.Sprintf("%ss", utils.CamelToSnake(dataType.Name())),
-		tagToInfo:      ti,
 		ignoreFields:   ifd,
 		index:          1,
 		isSetZeroValue: true,
@@ -128,7 +115,7 @@ func (f *Factory[T]) WithTrait(name string, tr setTraiter[T]) *Factory[T] {
 func (f *Factory[T]) Reset() {
 	f.index = 1
 	f.err = nil
-	f.associations = map[string][]interface{}{}
+	f.associations = [][]interface{}{}
 }
 
 // Build builds a value
@@ -140,9 +127,8 @@ func (f *Factory[T]) Build(ctx context.Context) *builder[T] {
 
 	if f.isSetZeroValue {
 		f.setNonZeroValues(&v, f.ignoreFields)
+		f.index++
 	}
-
-	f.index++
 
 	return &builder[T]{
 		ctx: ctx,
@@ -172,10 +158,10 @@ func (f *Factory[T]) BuildList(ctx context.Context, n int) *builderList[T] {
 
 		if f.isSetZeroValue {
 			f.setNonZeroValues(&v, f.ignoreFields)
+			f.index++
 		}
 
 		list[i] = &v
-		f.index++
 	}
 
 	return &builderList[T]{
@@ -220,9 +206,7 @@ func (b *builder[T]) Insert() (T, error) {
 	}
 
 	if len(b.f.associations) > 0 {
-		if err := b.setAss(); err != nil {
-			return b.f.empty, err
-		}
+		return b.insertWithAssoc(b.ctx)
 	}
 
 	val, err := b.f.db.Insert(b.ctx, db.InsertParams{StorageName: b.f.storageName, Value: b.v})
@@ -249,9 +233,7 @@ func (b *builderList[T]) Insert() ([]T, error) {
 	}
 
 	if len(b.f.associations) > 0 {
-		if err := b.setAss(); err != nil {
-			return nil, err
-		}
+		return b.insertWithAssoc(b.ctx)
 	}
 
 	// convert to any type
@@ -440,139 +422,53 @@ func (b *builderList[T]) SetZero(i int, fields ...string) *builderList[T] {
 
 // WihtOne set one association to the factory value.
 // Must pass a pointer to the association value.
-func (b *builder[T]) WithOne(v interface{}, ignoreFields ...string) *builder[T] {
+func (b *builder[T]) WithOne(vals ...interface{}) *builder[T] {
 	if b.err != nil {
 		return b
 	}
 
-	if err := b.f.setAssValue(v, ignoreFields); err != nil {
-		b.err = err
-		return b
+	for _, v := range vals {
+		if err := checkAssoc(v); err != nil {
+			b.err = err
+			return b
+		}
+		b.f.associations = append(b.f.associations, []interface{}{v})
 	}
 
-	name := reflect.TypeOf(v).Elem().Name()
-	b.f.associations[name] = []interface{}{v}
-	b.f.index++
 	return b
 }
 
 // WihtOne set one association to the factory value.
 // Must pass a pointer to the association value.
-func (b *builderList[T]) WithOne(v interface{}, ignoreFields ...string) *builderList[T] {
+func (b *builderList[T]) WithOne(vals ...interface{}) *builderList[T] {
 	if b.err != nil {
 		return b
 	}
 
-	if err := b.f.setAssValue(v, ignoreFields); err != nil {
-		b.err = err
-		return b
+	for _, v := range vals {
+		if err := checkAssoc(v); err != nil {
+			b.err = err
+			return b
+		}
+
+		b.f.associations = append(b.f.associations, []interface{}{v})
 	}
 
-	name := reflect.TypeOf(v).Elem().Name()
-	b.f.associations[name] = []interface{}{v}
-	b.f.index++
 	return b
 }
 
 // WithMany set many associations to the factory value.
 // Must pass a pointer to the association value.
-func (b *builderList[T]) WithMany(values []interface{}, ignoreFields ...string) *builderList[T] {
+func (b *builderList[T]) WithMany(vals []interface{}) *builderList[T] {
 	if b.err != nil {
 		return b
 	}
 
-	var curValName string
-	for _, v := range values {
-		if err := b.f.setAssValue(v, ignoreFields); err != nil {
-			b.err = err
-			return b
-		}
-
-		// check if the provided values are of the same type
-		// because we have to make sure all the value is pointer (setAssValue does that for us)
-		// before we can use Elem()
-		if curValName != "" && curValName != reflect.TypeOf(v).Elem().Name() {
-			b.err = errValueNotTheSameType
-			return b
-		}
-
-		name := reflect.TypeOf(v).Elem().Name()
-		b.f.associations[name] = append(b.f.associations[name], v)
-		b.f.index++
-		curValName = name
+	if err := checkAssocs(vals); err != nil {
+		b.err = err
+		return b
 	}
 
+	b.f.associations = append(b.f.associations, vals)
 	return b
-}
-
-// setAss sets and inserts the associations
-func (b *builder[T]) setAss() error {
-	// insert the associations
-	if err := b.f.insertAss(b.ctx); err != nil {
-		return err
-	}
-
-	// set the connection between the factory value and the associations
-	for name, vals := range b.f.associations {
-		// use vs[0] because we can make sure setAss(builder) only invoke with Build function
-		// which means there's only one factory value
-		// so that each associations only allow one value
-		t := b.f.tagToInfo[name]
-		if err := setForeignKey(b.v, t.fieldName, vals[0]); err != nil {
-			return err
-		}
-
-		// set the foreign field value if it's provided
-		if t.foreignField != "" {
-			if err := setField(b.v, t.foreignField, vals[0]); err != nil {
-				return err
-			}
-		}
-	}
-
-	// clear associations
-	b.f.associations = map[string][]interface{}{}
-
-	return nil
-}
-
-// setAss sets and inserts the associations
-func (b *builderList[T]) setAss() error {
-	// insert the associations
-	if err := b.f.insertAss(b.ctx); err != nil {
-		return err
-	}
-
-	// set the connection between the factory value and the associations
-	// use cachePrev because multiple values can have one association value
-	// e.g. multiple transaction belongs to one user
-	cachePrev := map[string]interface{}{}
-	for i, l := range b.list {
-		for name, vs := range b.f.associations {
-			var v interface{}
-			if i >= len(vs) {
-				v = cachePrev[name]
-			} else {
-				v = vs[i]
-				cachePrev[name] = vs[i]
-			}
-
-			t := b.f.tagToInfo[name]
-			if err := setForeignKey(l, t.fieldName, v); err != nil {
-				return err
-			}
-
-			// set the foreign field value if it's provided
-			if t.foreignField != "" {
-				if err := setField(l, t.foreignField, v); err != nil {
-					return err
-				}
-			}
-		}
-	}
-
-	// clear associations
-	b.f.associations = map[string][]interface{}{}
-
-	return nil
 }

--- a/gofacto_test.go
+++ b/gofacto_test.go
@@ -2573,9 +2573,6 @@ func setZero_OnBuilderListMany(t *testing.T) {
 	}
 }
 
-// TODO:
-// 1. when on builder with multi level association, insert successfully
-// 2. dag with cycle, return error
 func TestWithOne(t *testing.T) {
 	for _, fn := range map[string]func(*testing.T){
 		"when on builder, insert successfully":                       withOne_OnBuilder,

--- a/gofacto_test.go
+++ b/gofacto_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math/rand"
 	"reflect"
 	"testing"
 	"time"
@@ -55,9 +56,19 @@ func setIDField(val reflect.Value) error {
 	if !idField.IsValid() {
 		return errors.New("ID field not found")
 	}
-	idField.SetInt(1)
+	randomID := rand.Intn(1000) + 1
+	idField.SetInt(int64(randomID))
 
 	return nil
+}
+
+// testAssocStruct is a struct with a foreign key to test the association functionality.
+type testAssocStruct struct {
+	ID            int
+	ForeignKey    int  `gofacto:"foreignKey,struct:testStructWithID,field:ForeignValue"`
+	ForeignKey2   *int `gofacto:"foreignKey,struct:testStructWithID2,field:ForeignValue2,table:test_struct_with_id2s"`
+	ForeignValue  testStructWithID
+	ForeignValue2 *testStructWithID2
 }
 
 // testStructWithID is a struct with an ID field to test the insert functionality.
@@ -68,18 +79,26 @@ type testStructWithID struct {
 // testStructWithID2 is a struct with an ID field to test the association functionality.
 // This is for testing foreign field with pointer struct.
 type testStructWithID2 struct {
+	ID           int
+	ForeignKey   int `gofacto:"foreignKey,struct:testStructWithID3,field:ForeignValue"`
+	ForeignValue testStructWithID3
+	Name         string
+}
+
+// testStructWithID3 is a struct with an ID field to test the association functionality.
+type testStructWithID3 struct {
 	ID   int
 	Name string
 }
 
-// testAssocStruct is a struct with a foreign key to test the association functionality.
-type testAssocStruct struct {
-	ID          int
-	ForeignKey  int  `gofacto:"foreignKey,struct:testStructWithID,field:ForeignValue"`
-	ForeignKey2 *int `gofacto:"foreignKey,struct:testStructWithID2,field:ForeignValue2,table:test_struct_with_id2s"`
+type testStructWithCycle struct {
+	ID         int
+	ForeignKey int `gofacto:"foreignKey,struct:testStructWithCycle2"`
+}
 
-	ForeignValue  testStructWithID
-	ForeignValue2 *testStructWithID2
+type testStructWithCycle2 struct {
+	ID         int
+	ForeignKey int `gofacto:"foreignKey,struct:testStructWithCycle"`
 }
 
 // customType is a custom type to test the custom type functionality.
@@ -152,7 +171,6 @@ func new_NoConfig(t *testing.T) {
 	want := &Factory[testStruct]{
 		dataType:       reflect.TypeOf(testStruct{}),
 		storageName:    "test_structs",
-		tagToInfo:      map[string]tagInfo{},
 		ignoreFields:   []string{},
 		index:          1,
 		isSetZeroValue: true,
@@ -173,12 +191,12 @@ func new_WithBlueprint(t *testing.T) {
 	got := New(testStruct{}).WithBlueprint(blueprint)
 
 	want := &Factory[testStruct]{
-		blueprint:      blueprint,
-		dataType:       reflect.TypeOf(testStruct{}),
-		empty:          testStruct{},
-		associations:   map[string][]interface{}{},
-		storageName:    "test_structs",
-		tagToInfo:      map[string]tagInfo{},
+		blueprint:    blueprint,
+		dataType:     reflect.TypeOf(testStruct{}),
+		empty:        testStruct{},
+		associations: [][]interface{}{},
+		storageName:  "test_structs",
+
 		ignoreFields:   []string{},
 		index:          1,
 		isSetZeroValue: true,
@@ -196,7 +214,6 @@ func new_WithStorageName(t *testing.T) {
 	want := &Factory[testStruct]{
 		dataType:       reflect.TypeOf(testStruct{}),
 		storageName:    "test_storage",
-		tagToInfo:      map[string]tagInfo{},
 		ignoreFields:   []string{},
 		index:          1,
 		isSetZeroValue: true,
@@ -212,9 +229,9 @@ func new_WithDB(t *testing.T) {
 	got := New(testStruct{}).WithDB(db)
 
 	want := &Factory[testStruct]{
-		dataType:       reflect.TypeOf(testStruct{}),
-		storageName:    "test_structs",
-		tagToInfo:      map[string]tagInfo{},
+		dataType:    reflect.TypeOf(testStruct{}),
+		storageName: "test_structs",
+
 		ignoreFields:   []string{},
 		index:          1,
 		isSetZeroValue: true,
@@ -230,9 +247,9 @@ func new_WithIsSetZeroValue(t *testing.T) {
 	got := New(testStruct{}).WithIsSetZeroValue(false)
 
 	want := &Factory[testStruct]{
-		dataType:       reflect.TypeOf(testStruct{}),
-		storageName:    "test_structs",
-		tagToInfo:      map[string]tagInfo{},
+		dataType:    reflect.TypeOf(testStruct{}),
+		storageName: "test_structs",
+
 		ignoreFields:   []string{},
 		index:          1,
 		isSetZeroValue: false,
@@ -249,9 +266,9 @@ func new_WithTrait(t *testing.T) {
 	got := New(testStruct{}).WithTrait("test", trait)
 
 	want := &Factory[testStruct]{
-		dataType:       reflect.TypeOf(testStruct{}),
-		storageName:    "test_structs",
-		tagToInfo:      map[string]tagInfo{},
+		dataType:    reflect.TypeOf(testStruct{}),
+		storageName: "test_structs",
+
 		ignoreFields:   []string{},
 		index:          1,
 		isSetZeroValue: true,
@@ -269,12 +286,8 @@ func new_CorrectTagFormat(t *testing.T) {
 	got := New(testAssocStruct{})
 
 	want := &Factory[testAssocStruct]{
-		dataType:    reflect.TypeOf(testAssocStruct{}),
-		storageName: "test_assoc_structs",
-		tagToInfo: map[string]tagInfo{
-			"testStructWithID":  {tableName: "test_struct_with_ids", fieldName: "ForeignKey", foreignField: "ForeignValue"},
-			"testStructWithID2": {tableName: "test_struct_with_id2s", fieldName: "ForeignKey2", foreignField: "ForeignValue2"},
-		},
+		dataType:       reflect.TypeOf(testAssocStruct{}),
+		storageName:    "test_assoc_structs",
 		ignoreFields:   []string{},
 		index:          1,
 		isSetZeroValue: true,
@@ -605,12 +618,12 @@ func build_BluePrintNotSetZeroValues(t *testing.T) {
 		{
 			desc: "second build",
 			want: func() testStruct {
-				i2, i4 := 2, 4
-				str := "test2"
+				i1, i2 := 1, 2
+				str := "test1"
 
 				return testStruct{
-					Int:    i4,
-					PtrInt: &i2,
+					Int:    i2,
+					PtrInt: &i1,
 					Str:    str,
 					PtrStr: &str,
 				}
@@ -626,6 +639,8 @@ func build_BluePrintNotSetZeroValues(t *testing.T) {
 			}
 
 			if err := testutils.CompareVal(got, tt.want()); err != nil {
+				fmt.Println("got", got.Int)
+				fmt.Println("want", tt.want().Int)
 				t.Fatal(err.Error())
 			}
 		})
@@ -1054,8 +1069,8 @@ func buildList_BluePrintNotSetZeroValues(t *testing.T) {
 		{
 			desc: "first build",
 			want: func() []testStruct {
-				i1, i2, i3, i4 := 1, 2, 3, 4
-				str1, str2 := "test1", "test2"
+				i1, i2 := 1, 2
+				str1 := "test1"
 
 				return []testStruct{
 					{
@@ -1064,9 +1079,9 @@ func buildList_BluePrintNotSetZeroValues(t *testing.T) {
 						SlicePtrStruct: []*subStruct{{ID: i1, Name: str1}, {ID: i2, Name: str1}},
 					},
 					{
-						Int:            i4,
-						PtrStruct:      &subStruct{ID: i2, Name: str2},
-						SlicePtrStruct: []*subStruct{{ID: i2, Name: str2}, {ID: i3, Name: str2}},
+						Int:            i2,
+						PtrStruct:      &subStruct{ID: i1, Name: str1},
+						SlicePtrStruct: []*subStruct{{ID: i1, Name: str1}, {ID: i2, Name: str1}},
 					},
 				}
 			},
@@ -1074,19 +1089,19 @@ func buildList_BluePrintNotSetZeroValues(t *testing.T) {
 		{
 			desc: "second build",
 			want: func() []testStruct {
-				i3, i4, i5, i6, i8 := 3, 4, 5, 6, 8
-				str3, str4 := "test3", "test4"
+				i1, i2 := 1, 2
+				str1 := "test1"
 
 				return []testStruct{
 					{
-						Int:            i6,
-						PtrStruct:      &subStruct{ID: i3, Name: str3},
-						SlicePtrStruct: []*subStruct{{ID: i3, Name: str3}, {ID: i4, Name: str3}},
+						Int:            i2,
+						PtrStruct:      &subStruct{ID: i1, Name: str1},
+						SlicePtrStruct: []*subStruct{{ID: i1, Name: str1}, {ID: i2, Name: str1}},
 					},
 					{
-						Int:            i8,
-						PtrStruct:      &subStruct{ID: i4, Name: str4},
-						SlicePtrStruct: []*subStruct{{ID: i4, Name: str4}, {ID: i5, Name: str4}},
+						Int:            i2,
+						PtrStruct:      &subStruct{ID: i1, Name: str1},
+						SlicePtrStruct: []*subStruct{{ID: i1, Name: str1}, {ID: i2, Name: str1}},
 					},
 				}
 			},
@@ -1260,15 +1275,13 @@ func TestInsert(t *testing.T) {
 func insert_OnBuilderWithDB(t *testing.T) {
 	f := New(testStructWithID{}).WithDB(&mockDB{})
 
-	want := testStructWithID{ID: 1}
-
 	val, err := f.Build(mockCTX).Insert()
 	if err != nil {
 		t.Fatalf("unexpected error %v", err)
 	}
 
-	if testutils.CompareVal(val, want) != nil {
-		t.Fatalf("got: %v, want: %v", val, want)
+	if err := testutils.IsNotZeroVal(val); err != nil {
+		t.Fatal(err.Error())
 	}
 }
 
@@ -1307,15 +1320,13 @@ func insert_OnBuilderWithErr(t *testing.T) {
 func insert_OnBuilderListWithDB(t *testing.T) {
 	f := New(testStructWithID{}).WithDB(&mockDB{})
 
-	want := []testStructWithID{{ID: 1}, {ID: 1}}
-
 	val, err := f.BuildList(mockCTX, 2).Insert()
 	if err != nil {
 		t.Fatalf("unexpected error %v", err)
 	}
 
-	if testutils.CompareVal(val, want) != nil {
-		t.Fatalf("got: %v, want: %v", val, want)
+	if err := testutils.IsNotZeroVal(val); err != nil {
+		t.Fatal(err.Error())
 	}
 }
 
@@ -2562,18 +2573,23 @@ func setZero_OnBuilderListMany(t *testing.T) {
 	}
 }
 
+// TODO:
+// 1. when on builder with multi level association, insert successfully
+// 2. dag with cycle, return error
 func TestWithOne(t *testing.T) {
 	for _, fn := range map[string]func(*testing.T){
-		"when on builder, insert successfully":                      withOne_OnBuilder,
-		"when on builder not pass ptr, return error":                withOne_OnBuilderNotPassPtr,
-		"when on builder not pass struct, return error":             withOne_OnBuilderNotPassStruct,
-		"when on builder not pass struct in tag, return error":      withOne_OnBuilderNotPassStructInTag,
-		"when on builder with err, return error":                    withOne_OnBuilderWithErr,
-		"when on builder list, insert successfully":                 withOne_OnBuilderList,
-		"when on builder list not pass ptr, return error":           withOne_OnBuilderListNotPassPtr,
-		"when on builder list not pass struct, return error":        withOne_OnBuilderListNotPassStruct,
-		"when on builder list not pass struct in tag, return error": withOne_OnBuilderListNotPassStructInTag,
-		"when on builder list with err, return error":               withOne_OnBuilderListWithErr,
+		"when on builder, insert successfully":                       withOne_OnBuilder,
+		"when on builder with multi level, insert successfully":      withOne_OnBuilderMultiLevel,
+		"when on builder not pass ptr, return error":                 withOne_OnBuilderNotPassPtr,
+		"when on builder not pass struct, return error":              withOne_OnBuilderNotPassStruct,
+		"when on builder with err, return error":                     withOne_OnBuilderWithErr,
+		"when on builder with cycle, return error":                   withOne_OnBuilderWithCycle,
+		"when on builder list, insert successfully":                  withOne_OnBuilderList,
+		"when on builder list with multi level, insert successfully": withOne_OnBuilderListMultiLevel,
+		"when on builder list not pass ptr, return error":            withOne_OnBuilderListNotPassPtr,
+		"when on builder list not pass struct, return error":         withOne_OnBuilderListNotPassStruct,
+		"when on builder list with err, return error":                withOne_OnBuilderListWithErr,
+		"when on builder list with cycle, return error":              withOne_OnBuilderListWithCycle,
 	} {
 		t.Run(testutils.GetFunName(fn), func(t *testing.T) {
 			fn(t)
@@ -2595,8 +2611,8 @@ func withOne_OnBuilder(t *testing.T) {
 		t.Fatalf("ForeignKey should be %v", assVal.ID)
 	}
 
-	if val.ForeignKey2 != nil && *val.ForeignKey2 != assVal.ID {
-		t.Fatalf("ForeignKey2 should be %v", assVal.ID)
+	if val.ForeignKey2 != nil && *val.ForeignKey2 != assVal2.ID {
+		t.Fatalf("ForeignKey2 should be %v", assVal2.ID)
 	}
 
 	if err := testutils.CompareVal(val.ForeignValue, assVal); err != nil {
@@ -2604,6 +2620,43 @@ func withOne_OnBuilder(t *testing.T) {
 	}
 
 	if err := testutils.CompareVal(val.ForeignValue2, &assVal2); err != nil {
+		t.Fatal(err.Error())
+	}
+}
+
+func withOne_OnBuilderMultiLevel(t *testing.T) {
+	f := New(testAssocStruct{}).WithDB(&mockDB{})
+
+	assVal := testStructWithID{}
+	assVal2 := testStructWithID2{}
+	assVal3 := testStructWithID3{}
+
+	val, err := f.Build(mockCTX).
+		WithOne(&assVal, &assVal2, &assVal3).
+		Insert()
+	if err != nil {
+		t.Fatalf("unexpected error %v", err)
+	}
+
+	if val.ForeignKey != assVal.ID {
+		t.Fatalf("ForeignKey should be %v", assVal.ID)
+	}
+	if val.ForeignKey2 != nil && *val.ForeignKey2 != assVal2.ID {
+		t.Fatalf("ForeignKey2 should be %v", assVal2.ID)
+	}
+
+	if err := testutils.CompareVal(val.ForeignValue, assVal); err != nil {
+		t.Fatal(err.Error())
+	}
+	if err := testutils.CompareVal(val.ForeignValue2, &assVal2); err != nil {
+		t.Fatal(err.Error())
+	}
+
+	if assVal2.ForeignKey != assVal3.ID {
+		t.Fatalf("ForeignKey should be %v", assVal3.ID)
+	}
+
+	if err := testutils.CompareVal(assVal2.ForeignValue, assVal3); err != nil {
 		t.Fatal(err.Error())
 	}
 }
@@ -2641,22 +2694,6 @@ func withOne_OnBuilderNotPassStruct(t *testing.T) {
 	}
 }
 
-func withOne_OnBuilderNotPassStructInTag(t *testing.T) {
-	f := New(testAssocStruct{}).WithDB(&mockDB{})
-
-	want := testAssocStruct{}
-	wantErr := errNotFoundAtTag
-
-	val, err := f.Build(mockCTX).WithOne(&testStruct{}).Insert()
-	if !errors.Is(err, wantErr) {
-		t.Fatalf("error should be %v", wantErr)
-	}
-
-	if err := testutils.CompareVal(val, want); err != nil {
-		t.Fatal(err.Error())
-	}
-}
-
 func withOne_OnBuilderWithErr(t *testing.T) {
 	f := New(testAssocStruct{}).WithDB(&mockDB{})
 
@@ -2674,12 +2711,27 @@ func withOne_OnBuilderWithErr(t *testing.T) {
 	}
 }
 
+func withOne_OnBuilderWithCycle(t *testing.T) {
+	f := New(testStructWithCycle{}).WithDB(&mockDB{})
+
+	val, err := f.Build(mockCTX).WithOne(&testStructWithCycle2{}).Insert()
+	if !errors.Is(err, errCycleDependency) {
+		t.Fatalf("error should be %v", errCycleDependency)
+	}
+	if err := testutils.CompareVal(val, testStructWithCycle{}); err != nil {
+		t.Fatal(err.Error())
+	}
+}
+
 func withOne_OnBuilderList(t *testing.T) {
 	f := New(testAssocStruct{}).WithDB(&mockDB{})
 
 	assVal := testStructWithID{}
 	assVal2 := testStructWithID2{}
-	vals, err := f.BuildList(mockCTX, 2).WithOne(&assVal).WithOne(&assVal2).Insert()
+	vals, err := f.BuildList(mockCTX, 2).
+		WithOne(&assVal).
+		WithOne(&assVal2).
+		Insert()
 	if err != nil {
 		t.Fatalf("unexpected error %v", err)
 	}
@@ -2717,6 +2769,43 @@ func withOne_OnBuilderList(t *testing.T) {
 	}
 }
 
+func withOne_OnBuilderListMultiLevel(t *testing.T) {
+	f := New(testAssocStruct{}).WithDB(&mockDB{})
+
+	assVal := testStructWithID{}
+	assVal2 := testStructWithID2{}
+	assVal3 := testStructWithID3{}
+
+	vals, err := f.BuildList(mockCTX, 2).
+		WithOne(&assVal, &assVal2, &assVal3).
+		Insert()
+	if err != nil {
+		t.Fatalf("unexpected error %v", err)
+	}
+
+	for i := 0; i < 2; i++ {
+		if vals[i].ForeignKey != assVal.ID {
+			t.Fatalf("ForeignKey should be %v", assVal.ID)
+		}
+		if vals[i].ForeignKey2 != nil && *vals[i].ForeignKey2 != assVal2.ID {
+			t.Fatalf("ForeignKey2 should be %v", assVal2.ID)
+		}
+		if err := testutils.CompareVal(vals[i].ForeignValue, assVal); err != nil {
+			t.Fatal(err.Error())
+		}
+		if err := testutils.CompareVal(vals[i].ForeignValue2, &assVal2); err != nil {
+			t.Fatal(err.Error())
+		}
+	}
+
+	if assVal2.ForeignKey != assVal3.ID {
+		t.Fatalf("ForeignKey should be %v", assVal3.ID)
+	}
+	if err := testutils.CompareVal(assVal2.ForeignValue, assVal3); err != nil {
+		t.Fatal(err.Error())
+	}
+}
+
 func withOne_OnBuilderListNotPassPtr(t *testing.T) {
 	f := New(testAssocStruct{}).WithDB(&mockDB{})
 
@@ -2750,22 +2839,6 @@ func withOne_OnBuilderListNotPassStruct(t *testing.T) {
 	}
 }
 
-func withOne_OnBuilderListNotPassStructInTag(t *testing.T) {
-	f := New(testAssocStruct{}).WithDB(&mockDB{})
-
-	want := []testAssocStruct{}
-	wantErr := errNotFoundAtTag
-
-	vals, err := f.BuildList(mockCTX, 2).WithOne(&testStruct{}).Insert()
-	if !errors.Is(err, wantErr) {
-		t.Fatalf("error should be %v", wantErr)
-	}
-
-	if err := testutils.CompareVal(vals, want); err != nil {
-		t.Fatal(err.Error())
-	}
-}
-
 func withOne_OnBuilderListWithErr(t *testing.T) {
 	f := New(testAssocStruct{}).WithDB(&mockDB{})
 
@@ -2783,13 +2856,28 @@ func withOne_OnBuilderListWithErr(t *testing.T) {
 	}
 }
 
+func withOne_OnBuilderListWithCycle(t *testing.T) {
+	f := New(testStructWithCycle{}).WithDB(&mockDB{})
+
+	var want []testStructWithCycle
+	vals, err := f.BuildList(mockCTX, 2).WithOne(&testStructWithCycle2{}).Insert()
+	if !errors.Is(err, errCycleDependency) {
+		t.Fatalf("error should be %v", errCycleDependency)
+	}
+	if err := testutils.CompareVal(vals, want); err != nil {
+		t.Fatal(err.Error())
+	}
+}
+
 func TestWithMany(t *testing.T) {
 	for _, fn := range map[string]func(*testing.T){
-		"when withMany on builder, insert successfully":                 withMany_CorrectCase,
-		"when withMany on builder not pass ptr, return error":           withMany_NotPassPtr,
-		"when withMany on builder not pass struct, return error":        withMany_NotPassStruct,
-		"when withMany on builder not pass struct in tag, return error": withMany_NotPassStructInTag,
-		"when withMany on builder with err, return error":               withMany_WithErr,
+		"when withMany on builder, insert successfully":                  withMany_CorrectCase,
+		"when withMany on builder with multi level, insert successfully": withMany_MultiLevel,
+		"when withMany on builder not pass ptr, return error":            withMany_NotPassPtr,
+		"when withMany on builder not pass struct, return error":         withMany_NotPassStruct,
+		"when withMany on builder pass diff struct, return error":        withMany_PassDiffStruct,
+		"when withMany on builder with cycle, return error":              withMany_WithCycle,
+		"when withMany on builder with err, return error":                withMany_WithErr,
 	} {
 		t.Run(testutils.GetFunName(fn), func(t *testing.T) {
 			fn(t)
@@ -2842,6 +2930,44 @@ func withMany_CorrectCase(t *testing.T) {
 	}
 }
 
+func withMany_MultiLevel(t *testing.T) {
+	f := New(testAssocStruct{}).WithDB(&mockDB{})
+
+	assVals1 := []interface{}{&testStructWithID{}, &testStructWithID{}}
+	assVals2 := []interface{}{&testStructWithID2{}, &testStructWithID2{}}
+	assVals3 := []interface{}{&testStructWithID3{}, &testStructWithID3{}}
+	vals, err := f.BuildList(mockCTX, 2).
+		WithMany(assVals1).
+		WithMany(assVals2).
+		WithMany(assVals3).
+		Insert()
+	if err != nil {
+		t.Fatalf("unexpected error %v", err)
+	}
+
+	for i := 0; i < 2; i++ {
+		if vals[i].ForeignKey != assVals1[i].(*testStructWithID).ID {
+			t.Fatalf("ForeignKey should be %v", assVals1[i].(*testStructWithID).ID)
+		}
+		if vals[i].ForeignKey2 != nil && *vals[i].ForeignKey2 != assVals2[i].(*testStructWithID2).ID {
+			t.Fatalf("ForeignKey2 should be %v", assVals2[i].(*testStructWithID2).ID)
+		}
+		if err := testutils.CompareVal(vals[i].ForeignValue, *assVals1[i].(*testStructWithID)); err != nil {
+			t.Fatal(err.Error())
+		}
+		if err := testutils.CompareVal(vals[i].ForeignValue2, assVals2[i].(*testStructWithID2)); err != nil {
+			t.Fatal(err.Error())
+		}
+	}
+
+	if assVals2[0].(*testStructWithID2).ForeignKey != assVals3[0].(*testStructWithID3).ID {
+		t.Fatalf("ForeignKey should be %v", assVals3[0].(*testStructWithID3).ID)
+	}
+	if err := testutils.CompareVal(assVals2[0].(*testStructWithID2).ForeignValue, *assVals3[0].(*testStructWithID3)); err != nil {
+		t.Fatal(err.Error())
+	}
+}
+
 func withMany_NotPassPtr(t *testing.T) {
 	f := New(testAssocStruct{}).WithDB(&mockDB{})
 
@@ -2875,17 +3001,33 @@ func withMany_NotPassStruct(t *testing.T) {
 	}
 }
 
-func withMany_NotPassStructInTag(t *testing.T) {
+func withMany_PassDiffStruct(t *testing.T) {
 	f := New(testAssocStruct{}).WithDB(&mockDB{})
 
-	want := []testAssocStruct{}
-	wantErr := errNotFoundAtTag
+	assVal := testStructWithID{}
+	assVal2 := testStructWithID2{}
+	vals, err := f.BuildList(mockCTX, 2).WithMany([]interface{}{&assVal, &assVal2}).Insert()
 
-	vals, err := f.BuildList(mockCTX, 2).WithMany([]interface{}{&testStruct{}, &testStruct{}}).Insert()
-	if !errors.Is(err, wantErr) {
-		t.Fatalf("error should be %v", wantErr)
+	var want []testAssocStruct
+	if !errors.Is(err, errValueNotTheSameType) {
+		t.Fatalf("error should be %v", errValueNotTheSameType)
 	}
+	if err := testutils.CompareVal(vals, want); err != nil {
+		t.Fatal(err.Error())
+	}
+}
 
+func withMany_WithCycle(t *testing.T) {
+	f := New(testStructWithCycle{}).WithDB(&mockDB{})
+
+	vals, err := f.BuildList(mockCTX, 2).
+		WithMany([]interface{}{&testStructWithCycle2{}, &testStructWithCycle2{}}).
+		Insert()
+
+	var want []testStructWithCycle
+	if !errors.Is(err, errCycleDependency) {
+		t.Fatalf("error should be %v", errCycleDependency)
+	}
 	if err := testutils.CompareVal(vals, want); err != nil {
 		t.Fatal(err.Error())
 	}
@@ -2987,10 +3129,6 @@ func checkFactory[T any](got, want *Factory[T]) error {
 
 	if len(got.traits) != len(want.traits) {
 		return fmt.Errorf("traits should be %v", want.traits)
-	}
-
-	if testutils.CompareVal(got.tagToInfo, want.tagToInfo) != nil {
-		return fmt.Errorf("tagToInfo should be %v", want.tagToInfo)
 	}
 
 	if (got.blueprint == nil) != (want.blueprint == nil) {

--- a/tag.go
+++ b/tag.go
@@ -1,0 +1,105 @@
+package gofacto
+
+import (
+	"reflect"
+	"strings"
+
+	"github.com/eyo-chen/gofacto/internal/utils"
+)
+
+// tag represents the metadata parsed from the custom tag
+type tag struct {
+	fieldName    string
+	structName   string
+	tableName    string
+	foreignField string
+	omit         bool
+}
+
+// extractTag extracts the tag metadata from the struct type
+func extractTag(dataType reflect.Type) ([]string, error) {
+	var ignoreFields []string
+
+	err := processStructFields(dataType, func(t tag, hasTag bool) error {
+		if !hasTag {
+			return nil
+		}
+
+		if t.omit {
+			ignoreFields = append(ignoreFields, t.fieldName)
+		}
+
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return ignoreFields, nil
+}
+
+// processStructFields applies a given function to each field of a struct type
+func processStructFields(typ reflect.Type, fn func(tag tag, hasTag bool) error) error {
+	if typ.Kind() == reflect.Ptr {
+		typ = typ.Elem()
+	}
+
+	numField := typ.NumField()
+	for i := 0; i < numField; i++ {
+		field := typ.Field(i)
+		t, hasTag, err := parseTag(field)
+		if err != nil {
+			return err
+		}
+		if err := fn(t, hasTag); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// parseTag parses the tag string into a tag struct
+func parseTag(field reflect.StructField) (tag, bool, error) {
+	tagStr := field.Tag.Get(packageName)
+	if tagStr == "" {
+		return tag{}, false, nil
+	}
+
+	parts := strings.Split(tagStr, ";")
+	if len(parts) == 0 {
+		return tag{}, false, errTagFormat
+	}
+
+	t := tag{fieldName: field.Name}
+	for _, part := range parts {
+		if part == "omit" {
+			t.omit = true
+			continue
+		}
+
+		subParts := strings.Split(part, ",")
+		if subParts[0] != "foreignKey" {
+			return tag{}, false, errTagFormat
+		}
+
+		for _, subPart := range subParts[1:] {
+			kv := strings.SplitN(subPart, ":", 2)
+			switch kv[0] {
+			case "struct":
+				t.structName = kv[1]
+			case "table":
+				t.tableName = kv[1]
+			case "field":
+				t.foreignField = kv[1]
+			default:
+				return tag{}, false, errTagFormat
+			}
+		}
+	}
+
+	if t.tableName == "" {
+		t.tableName = utils.CamelToSnake(t.structName) + "s"
+	}
+
+	return t, true, nil
+}


### PR DESCRIPTION
- support multi-level associations
   1. add association value into slice (`WithOne` & `WithMany`)
   2. generate `nodeInfo` for later reference 
   3. use directed acyclic graph(DAG) to generate inserting correct order
   4. each node contains it's metadata and a list of foreign key reference
   5. populate random value
   6. set foreign key
   7. insert into db
- add more testing case
- extract certain logic to file